### PR TITLE
Feature/accessibility on error

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,7 @@ disabled_rules: # rule identifiers to exclude from running
     - trailing_whitespace
     - missing_docs
     - syntactic_sugar
+    - vertical_parameter_alignment
 opt_in_rules: # some rules are only opt-in
     - conditional_returns_on_newline
     - force_unwrapping

--- a/Source/DBNetworkStackError.swift
+++ b/Source/DBNetworkStackError.swift
@@ -65,7 +65,7 @@ extension DBNetworkStackError : CustomDebugStringConvertible {
     public var debugDescription: String {
         var result = ""
         
-        func appendData(result: inout String, data: Data?){
+        func appendData(result: inout String, data: Data?) {
             if let data = data, let string = String(data: data, encoding: .utf8) {
                 result.append("\n\tdata: \(string)")
             }

--- a/Source/DBNetworkStackError.swift
+++ b/Source/DBNetworkStackError.swift
@@ -60,40 +60,38 @@ public enum DBNetworkStackError: Error {
     
 }
 
+extension String {
+    fileprivate func appendingContentsOf(data: Data?) -> String {
+        if let data = data, let string = String(data: data, encoding: .utf8) {
+            return self.appending(string)
+        }
+        return self
+    }
+}
+
 extension DBNetworkStackError : CustomDebugStringConvertible {
     
     public var debugDescription: String {
-        var result = ""
-        
-        func appendData(result: inout String, data: Data?) {
-            if let data = data, let string = String(data: data, encoding: .utf8) {
-                result.append("\n\tdata: \(string)")
-            }
-        }
-        
         switch self {
         case .unknownError:
-            result = "Unknown error"
+            return "Unknown error"
         case .cancelled:
-            result = "Request cancelled"
+            return "Request cancelled"
         case .unauthorized(let response, let data):
-            result = "Authorization error: \(response)"
-            appendData(result: &result, data: data)
+            return "Authorization error: \(response), response: ".appendingContentsOf(data: data)
         case .clientError(let response, let data):
-            result = "Client error: \(response)"
-            appendData(result: &result, data: data)
+            if let response = response {
+                return "Client error: \((response)), response: ".appendingContentsOf(data: data)
+            }
+            return "Client error, response: ".appendingContentsOf(data: data)
         case .serializationError(let description, let data):
-            result = "Serialization error: \(description)"
-            appendData(result: &result, data: data)
+            return "Serialization error: \(description), response: ".appendingContentsOf(data: data)
         case .requestError(let error):
-            result = "Request error: \(error)"
+            return "Request error: \(error)"
         case .serverError(let response, let data):
-            result = "Server error: \(response)"
-            appendData(result: &result, data: data)
+            return "Server error: \(response), response: ".appendingContentsOf(data: data)
         case .missingBaseURL:
-            result = "Missing base url error"
+            return "Missing base url error"
         }
-        
-        return result
     }
 }

--- a/Source/DBNetworkStackError.swift
+++ b/Source/DBNetworkStackError.swift
@@ -33,14 +33,14 @@ import Foundation
 public enum DBNetworkStackError: Error {
     case unknownError
     case cancelled
-    case unauthorized(response: HTTPURLResponse)
-    case clientError(response: HTTPURLResponse?)
+    case unauthorized(response: HTTPURLResponse, data: Data?)
+    case clientError(response: HTTPURLResponse?, data: Data?)
     case serializationError(description: String, data: Data?)
     case requestError(error: Error)
-    case serverError(response: HTTPURLResponse?)
+    case serverError(response: HTTPURLResponse?, data: Data?)
     case missingBaseURL
     
-    init?(response: HTTPURLResponse?) {
+    init?(response: HTTPURLResponse?, data: Data?) {
         guard let response = response else {
             return nil
         }
@@ -48,11 +48,11 @@ public enum DBNetworkStackError: Error {
         switch response.statusCode {
         case 200..<300: return nil
         case 401:
-            self = .unauthorized(response: response)
+            self = .unauthorized(response: response, data: data)
         case 400...451:
-            self = .clientError(response: response)
+            self = .clientError(response: response, data: data)
         case 500...511:
-            self = .serverError(response: response)
+            self = .serverError(response: response, data: data)
         default:
             return nil
         }

--- a/Source/DBNetworkStackError.swift
+++ b/Source/DBNetworkStackError.swift
@@ -65,24 +65,31 @@ extension DBNetworkStackError : CustomDebugStringConvertible {
     public var debugDescription: String {
         var result = ""
         
+        func appendData(result: inout String, data: Data?){
+            if let data = data, let string = String(data: data, encoding: .utf8) {
+                result.append("\n\tdata: \(string)")
+            }
+        }
+        
         switch self {
         case .unknownError:
             result = "Unknown error"
         case .cancelled:
             result = "Request cancelled"
-        case .unauthorized(let response):
+        case .unauthorized(let response, let data):
             result = "Authorization error: \(response)"
-        case .clientError(let response):
+            appendData(result: &result, data: data)
+        case .clientError(let response, let data):
             result = "Client error: \(response)"
+            appendData(result: &result, data: data)
         case .serializationError(let description, let data):
             result = "Serialization error: \(description)"
-            if let data = data, let string = String(data: data, encoding: .utf8) {
-                result.append("\n\tdata: \(string)")
-            }
+            appendData(result: &result, data: data)
         case .requestError(let error):
             result = "Request error: \(error)"
-        case .serverError(let response):
+        case .serverError(let response, let data):
             result = "Server error: \(response)"
+            appendData(result: &result, data: data)
         case .missingBaseURL:
             result = "Missing base url error"
         }

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -72,7 +72,7 @@ extension NetworkResponseProcessing {
             
             throw DBNetworkStackError.requestError(error: error)
         }
-        if let responseError = DBNetworkStackError(response: response) {
+        if let responseError = DBNetworkStackError(response: response, data: data) {
             throw responseError
         }
         guard let data = data else {

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -101,9 +101,9 @@ extension NetworkResponseProcessing {
             DispatchQueue.main.async {
                 onCompletion(parsed)
             }
-        } catch let parsingError as DBNetworkStackError {
+        } catch let networkStackError as DBNetworkStackError {
             DispatchQueue.main.async {
-                return onError(parsingError)
+                return onError(networkStackError)
             }
         } catch {
             DispatchQueue.main.async {

--- a/Tests/DBNetworkStackTests/DBNetworkStackErrorTest.swift
+++ b/Tests/DBNetworkStackTests/DBNetworkStackErrorTest.swift
@@ -36,19 +36,24 @@ class DBNetworkStackErrorTest: XCTestCase {
         return HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)
     }
     
+    private lazy var testData: Data = {
+        return "test_string".data(using: .utf8)!
+    }()
+    
     func testInit_WithHTTPStatusCode400() {
         //Given
-        let response = urlResponseWith(statusCode: 400)
+        let expectedResponse = urlResponseWith(statusCode: 400)
         
         //When
-        guard let error = DBNetworkStackError(response: response) else {
+        guard let error = DBNetworkStackError(response: expectedResponse, data: testData) else {
             return XCTFail()
         }
         
         //Then
         switch error {
-        case .clientError(let response):
-            XCTAssertEqual(response, response)
+        case .clientError(let response, let data):
+            XCTAssertEqual(response, expectedResponse)
+            XCTAssertEqual(data, testData)
         default:
             XCTFail()
         }
@@ -56,17 +61,18 @@ class DBNetworkStackErrorTest: XCTestCase {
     
     func testInit_WithHTTPStatusCode401() {
         //Given
-        let response = urlResponseWith(statusCode: 401)
+        let expectedResponse = urlResponseWith(statusCode: 401)
         
         //When
-        guard let error = DBNetworkStackError(response: response) else {
+        guard let error = DBNetworkStackError(response: expectedResponse, data: testData) else {
             return XCTFail()
         }
         
         //Then
         switch error {
-        case .unauthorized(let response):
-            XCTAssertEqual(response, response)
+        case .unauthorized(let response, let data):
+            XCTAssertEqual(response, expectedResponse)
+            XCTAssertEqual(data, testData)
         default:
             XCTFail()
         }
@@ -77,7 +83,7 @@ class DBNetworkStackErrorTest: XCTestCase {
         let response = urlResponseWith(statusCode: 200)
         
         //When
-        let error = DBNetworkStackError(response: response)
+        let error = DBNetworkStackError(response: response, data: nil)
         
         //Then
         XCTAssertNil(error)
@@ -85,16 +91,17 @@ class DBNetworkStackErrorTest: XCTestCase {
     
     func testInit_WithHTTPStatusCode511() {
         //Given
-        let response = urlResponseWith(statusCode: 511)
+        let expectedResponse = urlResponseWith(statusCode: 511)
         //When
-        guard let error = DBNetworkStackError(response: response) else {
+        guard let error = DBNetworkStackError(response: expectedResponse, data: testData) else {
             return XCTFail()
         }
         
         //Then
         switch error {
-        case .serverError(let response):
-            XCTAssertEqual(response, response)
+        case .serverError(let response, let data):
+            XCTAssertEqual(response, expectedResponse)
+            XCTAssertEqual(data, testData)
         default:
             XCTFail()
         }
@@ -105,7 +112,7 @@ class DBNetworkStackErrorTest: XCTestCase {
         let response = urlResponseWith(statusCode: 900)
         
         //When
-        let error = DBNetworkStackError(response: response)
+        let error = DBNetworkStackError(response: response, data: nil)
         
         //Then
         XCTAssertNil(error)

--- a/Tests/DBNetworkStackTests/DBNetworkStackErrorTest.swift
+++ b/Tests/DBNetworkStackTests/DBNetworkStackErrorTest.swift
@@ -36,9 +36,7 @@ class DBNetworkStackErrorTest: XCTestCase {
         return HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)
     }
     
-    private lazy var testData: Data = {
-        return "test_string".data(using: .utf8)!
-    }()
+    private let testData: Data! = "test_string".data(using: .utf8)
     
     func testInit_WithHTTPStatusCode400() {
         //Given
@@ -117,4 +115,80 @@ class DBNetworkStackErrorTest: XCTestCase {
         //Then
         XCTAssertNil(error)
     }
+    
+    func testUnknownError_debug_description() {
+        //Given
+        let error: DBNetworkStackError = .unknownError
+        
+        //When
+        let debugDescription = error.debugDescription
+        
+        //Then
+        XCTAssertEqual(debugDescription, "Unknown error")
+    }
+    
+    func testUnknownError_cancelled_description() {
+        //Given
+        let error: DBNetworkStackError = .cancelled
+        
+        //When
+        let debugDescription = error.debugDescription
+        
+        //Then
+        XCTAssertEqual(debugDescription, "Request cancelled")
+    }
+
+    func testUnknownError_unauthorized_description() {
+        //Given
+        let response = HTTPURLResponse()
+        let data = "dataString".data(using: .utf8)
+        let error: DBNetworkStackError = .unauthorized(response: response, data: data)
+        
+        //When
+        let debugDescription = error.debugDescription
+        
+        //Then
+        XCTAssert(debugDescription.hasPrefix("Authorization error: <NSHTTPURLResponse: "))
+        XCTAssert(debugDescription.hasSuffix("> { URL: (null) } { status code: 0, headers {\n} }, response: dataString"))
+    }
+    
+    func testUnknownError_clientError_description() {
+        //Given
+        let response = HTTPURLResponse()
+        let data = "dataString".data(using: .utf8)
+        let error: DBNetworkStackError = .clientError(response: response, data: data)
+        
+        //When
+        let debugDescription = error.debugDescription
+        
+        //Then
+        XCTAssert(debugDescription.hasPrefix("Client error: <NSHTTPURLResponse: "))
+        XCTAssert(debugDescription.hasSuffix("> { URL: (null) } { status code: 0, headers {\n} }, response: dataString"))
+    }
+    
+    func testUnknownError_serializationError_description() {
+        //Given
+        let description = "Failed because..."
+        let data = "dataString".data(using: .utf8)
+        let error: DBNetworkStackError = .serializationError(description: description, data: data)
+        
+        //When
+        let debugDescription = error.debugDescription
+        
+        //Then
+        XCTAssertEqual(debugDescription, "Serialization error: Failed because..., response: dataString")
+    }
+    
+    func testUnknownError_requestError_description() {
+        //Given
+        let underlayingError = NSError(domain: "domain", code: 0, userInfo: ["test": "test"])
+        let error: DBNetworkStackError = .requestError(error: underlayingError)
+        
+        //When
+        let debugDescription = error.debugDescription
+        
+        //Then
+        XCTAssertEqual(debugDescription, "Request error: Error Domain=domain Code=0 \"(null)\" UserInfo={test=test}")
+    }
+
 }

--- a/Tests/DBNetworkStackTests/NetworkServiceTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceTest.swift
@@ -169,11 +169,15 @@ class NetworkServiceTest: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
     
+    private lazy var testData: Data = {
+        return "test_string".data(using: .utf8)!
+    }()
+    
     func testRequest_withStatusCode401Response() {
         //Given
         let url: URL! = URL(string: "https://bahn.de")
-        let response = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
-        networkAccess.changeMock(data: nil, response: response, error: nil)
+        let expectedResponse = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
+        networkAccess.changeMock(data: testData, response: expectedResponse, error: nil)
         let expection = expectation(description: "testOnError")
         
         //When
@@ -181,8 +185,9 @@ class NetworkServiceTest: XCTestCase {
             }, onError: { resultError in
                 //Then
                 switch resultError {
-                case .unauthorized(let res):
-                    XCTAssertEqual(res, response)
+                case .unauthorized(let response, let data):
+                    XCTAssertEqual(response, expectedResponse)
+                    XCTAssertEqual(data, self.testData)
                     expection.fulfill()
                 default:
                     XCTFail()


### PR DESCRIPTION
Makes response data available for the following error cases:
* `unauthorized`
* `clientError`
* `serverError`

When possible `debugDescription` contains string representation of data.