### PR TITLE
[WIP]Access http response

### DIFF
--- a/DBNetworkStack.xcodeproj/project.pbxproj
+++ b/DBNetworkStack.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		7C235E0B1DBF6E8500628DC9 /* DBNetworkStackError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C235E0A1DBF6E8500628DC9 /* DBNetworkStackError.swift */; };
-		7C653BC91E09325500199993 /* NetworkResponseProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C653BC81E09325500199993 /* NetworkResponseProcessingTests.swift */; };
+		7C653BC91E09325500199993 /* NetworkResponseProcessorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C653BC81E09325500199993 /* NetworkResponseProcessorTest.swift */; };
 		C60425081D76F6F400FD3B38 /* NetworkAccessProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60425071D76F6F400FD3B38 /* NetworkAccessProviding.swift */; };
 		C604250A1D76F79F00FD3B38 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60425091D76F79F00FD3B38 /* NetworkService.swift */; };
 		C60425101D78002400FD3B38 /* JSONArrayResourceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C604250F1D78002400FD3B38 /* JSONArrayResourceTest.swift */; };
@@ -41,12 +41,13 @@
 		C6A5DED41D760CC900BC38B1 /* JSONResourceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A5DED31D760CC900BC38B1 /* JSONResourceTest.swift */; };
 		C6A5DED61D760E5000BC38B1 /* NetworkAccessMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A5DED51D760E5000BC38B1 /* NetworkAccessMock.swift */; };
 		C6A5DEDA1D76A06000BC38B1 /* TrainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A5DED91D76A06000BC38B1 /* TrainModel.swift */; };
+		C6C21A391F21F90A0004A7EB /* NetworkResponseProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C21A381F21F90A0004A7EB /* NetworkResponseProcessor.swift */; };
+		C6C21A3B1F21FD150004A7EB /* DefaultMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C21A3A1F21FD150004A7EB /* DefaultMocks.swift */; };
 		C6C395941E04212F00413AD2 /* ModifyRequestNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C395931E04212F00413AD2 /* ModifyRequestNetworkService.swift */; };
 		C6C395961E0422AF00413AD2 /* ModifyRequestNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C395951E0422AF00413AD2 /* ModifyRequestNetworkService.swift */; };
 		C6F235D51D7DA75000E628D8 /* URLSessionNetworkAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F235D41D7DA75000E628D8 /* URLSessionNetworkAccess.swift */; };
 		C6F7E30D1E49DAB300FA625F /* URLSessionProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F7E30B1E49DAA600FA625F /* URLSessionProtocolMock.swift */; };
 		C6F7E3101E49DCBA00FA625F /* NetworkTaskMockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F7E30E1E49DC4900FA625F /* NetworkTaskMockTests.swift */; };
-		C6FE99961E51924000B02B17 /* NetworkResponseProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6FE99951E51924000B02B17 /* NetworkResponseProcessing.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,7 +63,7 @@
 /* Begin PBXFileReference section */
 		7C235E0A1DBF6E8500628DC9 /* DBNetworkStackError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBNetworkStackError.swift; sourceTree = "<group>"; };
 		7C40B9FD1D9D66A600620563 /* NetworkTaskMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NetworkTaskMock.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		7C653BC81E09325500199993 /* NetworkResponseProcessingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResponseProcessingTests.swift; sourceTree = "<group>"; };
+		7C653BC81E09325500199993 /* NetworkResponseProcessorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResponseProcessorTest.swift; sourceTree = "<group>"; };
 		C60425071D76F6F400FD3B38 /* NetworkAccessProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NetworkAccessProviding.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C60425091D76F79F00FD3B38 /* NetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NetworkService.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C604250F1D78002400FD3B38 /* JSONArrayResourceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = JSONArrayResourceTest.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -97,12 +98,13 @@
 		C6A5DED31D760CC900BC38B1 /* JSONResourceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = JSONResourceTest.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C6A5DED51D760E5000BC38B1 /* NetworkAccessMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NetworkAccessMock.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C6A5DED91D76A06000BC38B1 /* TrainModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrainModel.swift; sourceTree = "<group>"; };
+		C6C21A381F21F90A0004A7EB /* NetworkResponseProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResponseProcessor.swift; sourceTree = "<group>"; };
+		C6C21A3A1F21FD150004A7EB /* DefaultMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultMocks.swift; sourceTree = "<group>"; };
 		C6C395931E04212F00413AD2 /* ModifyRequestNetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifyRequestNetworkService.swift; sourceTree = "<group>"; };
 		C6C395951E0422AF00413AD2 /* ModifyRequestNetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifyRequestNetworkService.swift; sourceTree = "<group>"; };
 		C6F235D41D7DA75000E628D8 /* URLSessionNetworkAccess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = URLSessionNetworkAccess.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C6F7E30B1E49DAA600FA625F /* URLSessionProtocolMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionProtocolMock.swift; sourceTree = "<group>"; };
 		C6F7E30E1E49DC4900FA625F /* NetworkTaskMockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTaskMockTests.swift; sourceTree = "<group>"; };
-		C6FE99951E51924000B02B17 /* NetworkResponseProcessing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResponseProcessing.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,7 +172,7 @@
 				C6F7E30E1E49DC4900FA625F /* NetworkTaskMockTests.swift */,
 				C6816E201D87C51C003B699A /* URLSessionNetworkAccessTest.swift */,
 				C699E0761D917501006FE7C6 /* DBNetworkStackErrorTest.swift */,
-				7C653BC81E09325500199993 /* NetworkResponseProcessingTests.swift */,
+				7C653BC81E09325500199993 /* NetworkResponseProcessorTest.swift */,
 				C61E77881E49A57A00D55BB2 /* NetworkServiceMockTest.swift */,
 				C60FF0F11E5C94AC00818031 /* URLRequestConvertibleTest.swift */,
 			);
@@ -183,6 +185,7 @@
 			children = (
 				C6F7E30B1E49DAA600FA625F /* URLSessionProtocolMock.swift */,
 				C6A5DED51D760E5000BC38B1 /* NetworkAccessMock.swift */,
+				C6C21A3A1F21FD150004A7EB /* DefaultMocks.swift */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -214,11 +217,11 @@
 			isa = PBXGroup;
 			children = (
 				C60BE67D1D6B2C46006B0364 /* NetworkServiceProviding.swift */,
-				C6FE99951E51924000B02B17 /* NetworkResponseProcessing.swift */,
 				C60425091D76F79F00FD3B38 /* NetworkService.swift */,
 				C6C395931E04212F00413AD2 /* ModifyRequestNetworkService.swift */,
 				C6461F011E01678100E0B081 /* RetryNetworkService.swift */,
 				C6461F0A1E016C7700E0B081 /* NetworkServiceMock.swift */,
+				C6C21A381F21F90A0004A7EB /* NetworkResponseProcessor.swift */,
 			);
 			name = NetworkService;
 			sourceTree = "<group>";
@@ -400,7 +403,6 @@
 			files = (
 				C61348B91DACB4F2000F0583 /* ArrayResourceModeling.swift in Sources */,
 				C6C395941E04212F00413AD2 /* ModifyRequestNetworkService.swift in Sources */,
-				C6FE99961E51924000B02B17 /* NetworkResponseProcessing.swift in Sources */,
 				C60BE6911D6B2C46006B0364 /* JSONResource.swift in Sources */,
 				C622A7961E5C7F6500BB3D17 /* URLRequestConvertible.swift in Sources */,
 				C60BE6901D6B2C46006B0364 /* Resource.swift in Sources */,
@@ -409,10 +411,12 @@
 				C61E778C1E49D8A900D55BB2 /* NetworkTaskMock.swift in Sources */,
 				7C235E0B1DBF6E8500628DC9 /* DBNetworkStackError.swift in Sources */,
 				C65F087B1D757A3C00239CC1 /* JSONMappable.swift in Sources */,
+				C6C21A391F21F90A0004A7EB /* NetworkResponseProcessor.swift in Sources */,
 				C60BE68E1D6B2C46006B0364 /* JSONResourceModeling.swift in Sources */,
 				C6F235D51D7DA75000E628D8 /* URLSessionNetworkAccess.swift in Sources */,
 				C60BE68C1D6B2C46006B0364 /* ResourceModeling.swift in Sources */,
 				C60BE68F1D6B2C46006B0364 /* HTTPMethod.swift in Sources */,
+				C6C21A3B1F21FD150004A7EB /* DefaultMocks.swift in Sources */,
 				C68FF1F51E1A64CB00A2513F /* Ressource+Map.swift in Sources */,
 				C604250A1D76F79F00FD3B38 /* NetworkService.swift in Sources */,
 				C6461F051E0167C900E0B081 /* RetryNetworkTask.swift in Sources */,
@@ -433,7 +437,7 @@
 				C61E77891E49A57A00D55BB2 /* NetworkServiceMockTest.swift in Sources */,
 				C6A5DEDA1D76A06000BC38B1 /* TrainModel.swift in Sources */,
 				C6816E211D87C51C003B699A /* URLSessionNetworkAccessTest.swift in Sources */,
-				7C653BC91E09325500199993 /* NetworkResponseProcessingTests.swift in Sources */,
+				7C653BC91E09325500199993 /* NetworkResponseProcessorTest.swift in Sources */,
 				C6461F081E0167FA00E0B081 /* RetryTaskTest.swift in Sources */,
 				C60425101D78002400FD3B38 /* JSONArrayResourceTest.swift in Sources */,
 				C6F7E30D1E49DAB300FA625F /* URLSessionProtocolMock.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ let request = URLRequest(path: "/", baseURL: url)
 let resource = Resource(request: request, parse: { String(data: $0, encoding: .utf8) })
 
 ```
-Request your resource and handle the response
+Request your resource and handle the result
 ```swift
 networkService.request(resource, onCompletion: { htmlText in
     print(htmlText)
@@ -100,6 +100,17 @@ struct XMLResource<T : XMLMappable> : ResourceModeling {
 ```XMLMappable``` defines the protocol, response model objects must conform to. The model class conforming to this protocol is responsible to convert a generic representation of the model into it’s specialized form.
 ```XMLResource<T : XMLMappable>``` defines a resource based on a given ```XMLMappable``` model. The parse function is responsible of converting raw response data to a generic representation.
 
+## Accessing HTTPResponse
+
+Request your resource and handle the result & response. This is similar to just requesting a resulting model.
+```swift
+networkService.request(resource, onCompletionWithResponse: { htmlText, response in
+    print(htmlText)
+}, onError: { error in
+    //Handle errors
+})
+
+```
 
 ## Protocol oriented architecture / Exchangability
 

--- a/Source/ArrayResourceModeling.swift
+++ b/Source/ArrayResourceModeling.swift
@@ -31,6 +31,7 @@ import Foundation
  `ArrayResourceModeling` describes a remote resource of generic type structured in an array.
  The resource type can be fetched via HTTP(s) and parsed into the coresponding model object.
  */
+@available(*, deprecated, message: "Build generic functions/classes which use `ResourceModeling.Element == Array<T>`")
 public protocol ArrayResourceModeling: ResourceModeling {
     associatedtype Element
     associatedtype Model = Array<Element>

--- a/Source/ModifyRequestNetworkService.swift
+++ b/Source/ModifyRequestNetworkService.swift
@@ -46,6 +46,7 @@ public final class ModifyRequestNetworkService: NetworkServiceProviding {
         self.requestModifications = requestModifications
     }
     
+    @discardableResult
     public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletionWithResponse: @escaping (T.Model, HTTPURLResponse) -> Void,
                         onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         let request = requestModifications.reduce(resource.request, { request, modify in

--- a/Source/ModifyRequestNetworkService.swift
+++ b/Source/ModifyRequestNetworkService.swift
@@ -46,13 +46,13 @@ public final class ModifyRequestNetworkService: NetworkServiceProviding {
         self.requestModifications = requestModifications
     }
     
-    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
+    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletionWithResponse: @escaping (T.Model, HTTPURLResponse) -> Void,
                         onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         let request = requestModifications.reduce(resource.request, { request, modify in
             return modify(request)
         })
         let newResource = Resource(request: request, parse: resource.parse)
-        return networkService.request(queue: queue, resource: newResource, onCompletion: onCompletion, onError: onError)
+        return networkService.request(queue: queue, resource: newResource, onCompletionWithResponse: onCompletionWithResponse, onError: onError)
     }
 }
 

--- a/Source/ModifyRequestNetworkService.swift
+++ b/Source/ModifyRequestNetworkService.swift
@@ -46,13 +46,13 @@ public final class ModifyRequestNetworkService: NetworkServiceProviding {
         self.requestModifications = requestModifications
     }
     
-    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model) -> Void,
+    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
                         onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         let request = requestModifications.reduce(resource.request, { request, modify in
             return modify(request)
         })
         let newResource = Resource(request: request, parse: resource.parse)
-        return networkService.request(queue: queue, newResource, onCompletion: onCompletion, onError: onError)
+        return networkService.request(queue: queue, resource: newResource, onCompletion: onCompletion, onError: onError)
     }
 }
 

--- a/Source/NetworkResponseProcessing.swift
+++ b/Source/NetworkResponseProcessing.swift
@@ -85,7 +85,7 @@ extension NetworkResponseProcessing {
     ///   - onCompletion: completion block which gets called on the given `queue`.
     ///   - onError: error block which gets called on the given `queue`.
     func processAsyncResponse<T: ResourceModeling>(queue: DispatchQueue, response: HTTPURLResponse?, resource: T, data: Data?,
-                              error: Error?, onCompletion: @escaping (T.Model) -> Void, onError: @escaping (DBNetworkStackError) -> Void) {
+                              error: Error?, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void, onError: @escaping (DBNetworkStackError) -> Void) {
         do {
             let parsed = try process(
                 response: response,
@@ -94,7 +94,7 @@ extension NetworkResponseProcessing {
                 error: error
             )
             queue.async {
-                onCompletion(parsed)
+                onCompletion(parsed, response!) //Is reposne never nil here??
             }
         } catch let parsingError as DBNetworkStackError {
             queue.async {

--- a/Source/NetworkResponseProcessing.swift
+++ b/Source/NetworkResponseProcessing.swift
@@ -94,7 +94,11 @@ extension NetworkResponseProcessing {
                 error: error
             )
             queue.async {
-                onCompletion(parsed, response!) //Is reposne never nil here??
+                if let response = response {
+                    onCompletion(parsed, response)
+                } else {
+                    onError(DBNetworkStackError.unknownError)
+                }
             }
         } catch let parsingError as DBNetworkStackError {
             queue.async {

--- a/Source/NetworkResponseProcessor.swift
+++ b/Source/NetworkResponseProcessor.swift
@@ -87,7 +87,7 @@ open class NetworkResponseProcessor {
                 }
             }
         } catch let parsingError {
-            let dbBetworkError: DBNetworkStackError! = parsingError as? DBNetworkStackError
+            let dbNetworkError: DBNetworkStackError! = parsingError as? DBNetworkStackError
             queue.async {
                 return onError(dbBetworkError)
             }

--- a/Source/NetworkResponseProcessor.swift
+++ b/Source/NetworkResponseProcessor.swift
@@ -89,7 +89,7 @@ open class NetworkResponseProcessor {
         } catch let parsingError {
             let dbNetworkError: DBNetworkStackError! = parsingError as? DBNetworkStackError
             queue.async {
-                return onError(dbBetworkError)
+                return onError(dbNetworkError)
             }
         }
     }

--- a/Source/NetworkResponseProcessor.swift
+++ b/Source/NetworkResponseProcessor.swift
@@ -19,17 +19,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 //  DEALINGS IN THE SOFTWARE.
 //
-//
-//  NetworkResponseProcessing.swift
-//  DBNetworkStack
-//
-//  Created by Lukas Schmidt on 13.02.17.
-//
 
 import Foundation
 import Dispatch
 
-public protocol NetworkResponseProcessing {
+open class NetworkResponseProcessor {
     /**
      Processes the results of an HTTPRequest and parses the result the matching Model type of the given resource.
      
@@ -42,13 +36,8 @@ public protocol NetworkResponseProcessing {
      
      - returns: the parsed model object.
      */
-    func process<T: ResourceModeling>(response: HTTPURLResponse?, resource: T, data: Data?, error: Error?) throws -> T.Model
-}
-
-extension NetworkResponseProcessing {
-    public func process<T: ResourceModeling>(response: HTTPURLResponse?, resource: T, data: Data?, error: Error?) throws -> T.Model {
+    func process<T: ResourceModeling>(response: HTTPURLResponse?, resource: T, data: Data?, error: Error?) throws -> T.Model {
         if let error = error {
-            
             if case URLError.cancelled = error {
                 throw DBNetworkStackError.cancelled
             }
@@ -69,9 +58,6 @@ extension NetworkResponseProcessing {
             throw DBNetworkStackError.serializationError(description: "Unknown serialization error", data: data)
         }
     }
-}
-
-extension NetworkResponseProcessing {
     
     /// This parseses a `HTTPURLResponse` with a given resource into the result type of the resource or errors.
     /// The result will be return via a blocks onCompletion/onError.
@@ -100,13 +86,10 @@ extension NetworkResponseProcessing {
                     onError(DBNetworkStackError.unknownError)
                 }
             }
-        } catch let parsingError as DBNetworkStackError {
+        } catch let parsingError {
+            let dbBetworkError: DBNetworkStackError! = parsingError as? DBNetworkStackError
             queue.async {
-                return onError(parsingError)
-            }
-        } catch {
-            queue.async {
-                return onError(.unknownError)
+                return onError(dbBetworkError)
             }
         }
     }

--- a/Source/NetworkService.swift
+++ b/Source/NetworkService.swift
@@ -45,7 +45,7 @@ public final class NetworkService: NetworkServiceProviding {
     }
     
     @discardableResult
-    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model) -> Void,
+    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
                         onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         let request = resource.request.asURLRequest()
         let dataTask = networkAccess.load(request: request, callback: { data, response, error in

--- a/Source/NetworkService.swift
+++ b/Source/NetworkService.swift
@@ -47,12 +47,12 @@ public final class NetworkService: NetworkServiceProviding {
     }
     
     @discardableResult
-    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
+    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletionWithResponse: @escaping (T.Model, HTTPURLResponse) -> Void,
                         onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         let request = resource.request.asURLRequest()
         let dataTask = networkAccess.load(request: request, callback: { data, response, error in
             self.networkResponseProcessor.processAsyncResponse(queue: queue, response: response, resource: resource, data: data,
-                                      error: error, onCompletion: onCompletion, onError: onError)
+                                      error: error, onCompletion: onCompletionWithResponse, onError: onError)
         })
         return dataTask
     }

--- a/Source/NetworkService.swift
+++ b/Source/NetworkService.swift
@@ -33,6 +33,7 @@ import Dispatch
  */
 public final class NetworkService: NetworkServiceProviding {
     let networkAccess: NetworkAccessProviding
+    let networkResponseProcessor: NetworkResponseProcessor
     
     /**
      Creates an `NetworkService` instance with a given networkAccess and a map of endPoints
@@ -42,6 +43,7 @@ public final class NetworkService: NetworkServiceProviding {
      */
     public init(networkAccess: NetworkAccessProviding) {
         self.networkAccess = networkAccess
+        self.networkResponseProcessor = NetworkResponseProcessor()
     }
     
     @discardableResult
@@ -49,7 +51,7 @@ public final class NetworkService: NetworkServiceProviding {
                         onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         let request = resource.request.asURLRequest()
         let dataTask = networkAccess.load(request: request, callback: { data, response, error in
-            self.processAsyncResponse(queue: queue, response: response, resource: resource, data: data,
+            self.networkResponseProcessor.processAsyncResponse(queue: queue, response: response, resource: resource, data: data,
                                       error: error, onCompletion: onCompletion, onError: onError)
         })
         return dataTask

--- a/Source/NetworkServiceMock.swift
+++ b/Source/NetworkServiceMock.swift
@@ -83,6 +83,7 @@ public class NetworkServiceMock: NetworkServiceProviding {
     ///
     /// - Parameters:
     ///   - data: the mock response from the server. `Data()` by default
+    ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
     ///   - count: the count how often the response gets triggerd. 1 by default
     public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int = 1) {
         for _ in 0...count {
@@ -97,6 +98,7 @@ public class NetworkServiceMock: NetworkServiceProviding {
     ///
     /// - Parameters:
     ///   - data: the mock response from the server. `Data()` by default
+    ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
     ///   - count: the count how often the response gets triggerd. 1 by default
     public func returnSuccess<T>(with serializedResponse: T, httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int = 1) {
         for _ in 0...count {

--- a/Source/NetworkServiceMock.swift
+++ b/Source/NetworkServiceMock.swift
@@ -44,7 +44,7 @@ public class NetworkServiceMock: NetworkServiceProviding {
     public var nextNetworkTask: NetworkTaskRepresenting?
 
     @discardableResult
-    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
+    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletionWithResponse: @escaping (T.Model, HTTPURLResponse) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         lastRequest = resource.request
         requestCount += 1
@@ -52,13 +52,13 @@ public class NetworkServiceMock: NetworkServiceProviding {
             guard let result = try? resource.parse(data) else {
                 fatalError("Could not parse data into matching result type")
             }
-            onCompletion(result, response)
+            onCompletionWithResponse(result, response)
         }
         onTypedSuccess = { anyResult, response in
             guard let typedResult =  anyResult as? T.Model else {
                 fatalError("Extected type of \(T.Model.self)")
             }
-            onCompletion(typedResult, response)
+            onCompletionWithResponse(typedResult, response)
         }
         onErrorCallback = { error in
             onError(error)

--- a/Source/NetworkServiceMock.swift
+++ b/Source/NetworkServiceMock.swift
@@ -31,8 +31,8 @@ import Dispatch
 
 public class NetworkServiceMock: NetworkServiceProviding {
     private var onErrorCallback: ((DBNetworkStackError) -> Void)?
-    private var onSuccess: ((Data) -> Void)?
-    private var onTypedSuccess: ((Any) -> Void)?
+    private var onSuccess: ((Data, HTTPURLResponse) -> Void)?
+    private var onTypedSuccess: ((Any, HTTPURLResponse) -> Void)?
     
     public init() {}
     
@@ -44,21 +44,21 @@ public class NetworkServiceMock: NetworkServiceProviding {
     public var nextNetworkTask: NetworkTaskRepresenting?
 
     @discardableResult
-    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model) -> Void,
+    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         lastRequest = resource.request
         requestCount += 1
-        onSuccess = { data in
+        onSuccess = { data, response in
             guard let result = try? resource.parse(data) else {
                 fatalError("Could not parse data into matching result type")
             }
-            onCompletion(result)
+            onCompletion(result, response)
         }
-        onTypedSuccess = { anyResult in
+        onTypedSuccess = { anyResult, response in
             guard let typedResult =  anyResult as? T.Model else {
                 fatalError("Extected type of \(T.Model.self)")
             }
-            onCompletion(typedResult)
+            onCompletion(typedResult, response)
         }
         onErrorCallback = { error in
             onError(error)
@@ -84,9 +84,9 @@ public class NetworkServiceMock: NetworkServiceProviding {
     /// - Parameters:
     ///   - data: the mock response from the server. `Data()` by default
     ///   - count: the count how often the response gets triggerd. 1 by default
-    public func returnSuccess(with data: Data = Data(), count: Int = 1) {
+    public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int = 1) {
         for _ in 0...count {
-            onSuccess?(data)
+            onSuccess?(data, httpResponse)
         }
         releaseCapturedCallbacks()
     }
@@ -98,9 +98,9 @@ public class NetworkServiceMock: NetworkServiceProviding {
     /// - Parameters:
     ///   - data: the mock response from the server. `Data()` by default
     ///   - count: the count how often the response gets triggerd. 1 by default
-    public func returnSuccess<T>(with serializedResponse: T, count: Int = 1) {
+    public func returnSuccess<T>(with serializedResponse: T, httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int = 1) {
         for _ in 0...count {
-            onTypedSuccess?(serializedResponse)
+            onTypedSuccess?(serializedResponse, httpResponse)
         }
         releaseCapturedCallbacks()
     }

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -75,8 +75,8 @@ extension NetworkServiceProviding {
      - returns: the request
      */
     @discardableResult
-    func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model) -> Void,
+    func request<T: ResourceModeling>(queue: DispatchQueue  = .main, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
-        return request(queue: queue, resource: resource, onCompletion: { model, _ in onCompletion(model) }, onError: onError)
+        return request(queue: queue, resource: resource, onCompletion: onCompletion, onError: onError)
     }
 }

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -59,9 +59,9 @@ public extension NetworkServiceProviding {
      - returns: the request
      */
     @discardableResult
-    func request<T: ResourceModeling>(queue: DispatchQueue = .main, _ resource: T, onCompletion: @escaping (T.Model) -> Void,
+    func request<T: ResourceModeling>(_ resource: T, onCompletion: @escaping (T.Model) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
-        return request(queue: queue, resource: resource, onCompletion: { model, _ in onCompletion(model) }, onError: onError)
+        return request(queue: .main, resource: resource, onCompletion: { model, _ in onCompletion(model) }, onError: onError)
     }
     
     /**
@@ -75,8 +75,8 @@ public extension NetworkServiceProviding {
      - returns: the request
      */
     @discardableResult
-    func request<T: ResourceModeling>(queue: DispatchQueue  = .main, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
+    func request<T: ResourceModeling>(_ resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
-        return request(queue: queue, resource: resource, onCompletion: onCompletion, onError: onError)
+        return request(queue: .main, resource: resource, onCompletion: onCompletion, onError: onError)
     }
 }

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -43,7 +43,7 @@ public protocol NetworkServiceProviding: NetworkResponseProcessing {
      - returns: the request
      */
     @discardableResult
-    func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model) -> Void,
+    func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting
 }
 
@@ -61,6 +61,22 @@ extension NetworkServiceProviding {
     @discardableResult
     public func request<T: ResourceModeling>(queue: DispatchQueue = .main, _ resource: T, onCompletion: @escaping (T.Model) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
-        return request(queue: queue, resource: resource, onCompletion: onCompletion, onError: onError)
+        return request(queue: queue, resource: resource, onCompletion: { model, _ in onCompletion(model) }, onError: onError)
+    }
+    
+    /**
+     Fetches a resource asynchrony from remote location
+     
+     - parameter queue: The DispatchQueue to execute the completion and error block on.
+     - parameter resource: The resource you want to fetch.
+     - parameter onComplition: Callback which gets called when fetching and tranforming into model succeeds.
+     - parameter onError: Callback which gets called when fetching or tranforming fails.
+     
+     - returns: the request
+     */
+    @discardableResult
+    func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model) -> Void,
+                 onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
+        return request(queue: queue, resource: resource, onCompletion: { model, _ in onCompletion(model) }, onError: onError)
     }
 }

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -43,7 +43,7 @@ public protocol NetworkServiceProviding {
      - returns: the request
      */
     @discardableResult
-    func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
+    func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletionWithResponse: @escaping (T.Model, HTTPURLResponse) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting
 }
 
@@ -61,7 +61,7 @@ public extension NetworkServiceProviding {
     @discardableResult
     func request<T: ResourceModeling>(_ resource: T, onCompletion: @escaping (T.Model) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
-        return request(queue: .main, resource: resource, onCompletion: { model, _ in onCompletion(model) }, onError: onError)
+        return request(queue: .main, resource: resource, onCompletionWithResponse: { model, _ in onCompletion(model) }, onError: onError)
     }
     
     /**
@@ -75,8 +75,8 @@ public extension NetworkServiceProviding {
      - returns: the request
      */
     @discardableResult
-    func request<T: ResourceModeling>(_ resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
+    func request<T: ResourceModeling>(_ resource: T, onCompletionWithResponse: @escaping (T.Model, HTTPURLResponse) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
-        return request(queue: .main, resource: resource, onCompletion: onCompletion, onError: onError)
+        return request(queue: .main, resource: resource, onCompletionWithResponse: onCompletionWithResponse, onError: onError)
     }
 }

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -33,11 +33,11 @@ import Dispatch
  */
 public protocol NetworkServiceProviding {
     /**
-     Fetches a resource asynchrony from remote location
+     Fetches a resource asynchrony from remote location.
      
      - parameter queue: The DispatchQueue to execute the completion and error block on.
      - parameter resource: The resource you want to fetch.
-     - parameter onComplition: Callback which gets called when fetching and tranforming into model succeeds.
+     - parameter onCompletionWithResponse: Callback which gets called when fetching and tranforming into model succeeds.
      - parameter onError: Callback which gets called when fetching or tranforming fails.
      
      - returns: the request
@@ -49,9 +49,20 @@ public protocol NetworkServiceProviding {
 
 public extension NetworkServiceProviding {
     /**
-     Fetches a resource asynchrony from remote location
+     Fetches a resource asynchrony from remote location. Completion and Error block will be called on the main thread.
      
-     - parameter queue: The DispatchQueue to execute the completion and error block on. MainQueue by default.
+     ```swift
+     
+     let networkService: NetworkServiceProviding = //
+     let resource: Ressource<String> = //
+     
+     networkService.request(resource, onCompletion: { htmlText in
+        print(htmlText)
+     }, onError: { error in
+        //Handle errors
+     })
+     ```
+     
      - parameter resource: The resource you want to fetch.
      - parameter onComplition: Callback which gets called when fetching and tranforming into model succeeds.
      - parameter onError: Callback which gets called when fetching or tranforming fails.
@@ -65,11 +76,10 @@ public extension NetworkServiceProviding {
     }
     
     /**
-     Fetches a resource asynchrony from remote location
+     Fetches a resource asynchrony from remote location. Completion and Error block will be called on the main thread.
      
-     - parameter queue: The DispatchQueue to execute the completion and error block on.
      - parameter resource: The resource you want to fetch.
-     - parameter onComplition: Callback which gets called when fetching and tranforming into model succeeds.
+     - parameter onCompletionWithResponse: Callback which gets called when fetching and tranforming into model succeeds.
      - parameter onError: Callback which gets called when fetching or tranforming fails.
      
      - returns: the request

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -47,7 +47,7 @@ public protocol NetworkServiceProviding {
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting
 }
 
-extension NetworkServiceProviding {
+public extension NetworkServiceProviding {
     /**
      Fetches a resource asynchrony from remote location
      
@@ -59,7 +59,7 @@ extension NetworkServiceProviding {
      - returns: the request
      */
     @discardableResult
-    public func request<T: ResourceModeling>(queue: DispatchQueue = .main, _ resource: T, onCompletion: @escaping (T.Model) -> Void,
+    func request<T: ResourceModeling>(queue: DispatchQueue = .main, _ resource: T, onCompletion: @escaping (T.Model) -> Void,
                  onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         return request(queue: queue, resource: resource, onCompletion: { model, _ in onCompletion(model) }, onError: onError)
     }

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -31,7 +31,7 @@ import Dispatch
 /**
  `NetworkServiceProviding` provides access to remote resources.
  */
-public protocol NetworkServiceProviding: NetworkResponseProcessing {
+public protocol NetworkServiceProviding {
     /**
      Fetches a resource asynchrony from remote location
      

--- a/Source/NetworkServiceProviding.swift
+++ b/Source/NetworkServiceProviding.swift
@@ -33,7 +33,7 @@ import Dispatch
  */
 public protocol NetworkServiceProviding {
     /**
-     Fetches a resource asynchrony from remote location.
+     Fetches a resource asynchronously from remote location.
      
      - parameter queue: The DispatchQueue to execute the completion and error block on.
      - parameter resource: The resource you want to fetch.
@@ -49,7 +49,7 @@ public protocol NetworkServiceProviding {
 
 public extension NetworkServiceProviding {
     /**
-     Fetches a resource asynchrony from remote location. Completion and Error block will be called on the main thread.
+     Fetches a resource asynchronously from remote location. Completion and Error block will be called on the main thread.
      
      ```swift
      
@@ -76,7 +76,7 @@ public extension NetworkServiceProviding {
     }
     
     /**
-     Fetches a resource asynchrony from remote location. Completion and Error block will be called on the main thread.
+     Fetches a resource asynchronously from remote location. Completion and Error block will be called on the main thread.
      
      - parameter resource: The resource you want to fetch.
      - parameter onCompletionWithResponse: Callback which gets called when fetching and tranforming into model succeeds.

--- a/Source/ResourceModeling.swift
+++ b/Source/ResourceModeling.swift
@@ -30,6 +30,7 @@ import Foundation
  `ResourceModeling` describes a remote resource of generic type.
  The type can be fetched via HTTP(s) and parsed into the coresponding model object.
  */
+@available(*, deprecated, message: "Use `Resource<T> to compose a custom Resource`")
 public protocol ResourceModeling {
     /**
      Model object which coresponds to the remote resource

--- a/Source/RetryNetworkService.swift
+++ b/Source/RetryNetworkService.swift
@@ -61,15 +61,15 @@ public final class RetryNetworkService: NetworkServiceProviding {
     }
     
     @discardableResult
-    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model) -> Void,
+    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
                         onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         let retryTask = RetryNetworkTask(maxmimumNumberOfRetries: numberOfRetries, idleTimeInterval: idleTimeInterval, shouldRetry: shouldRetry,
                                   onSuccess: onCompletion, onError: onError, retryAction: { completion, error in
-                                    return self.networkService.request(queue: queue, resource, onCompletion: completion, onError: error)
+                                    return self.networkService.request(queue: queue, resource: resource, onCompletion: completion, onError: error)
         }, dispatchRetry: { [weak self] disptachTime, block in
             self?.dispatchRetry(disptachTime, block)
         })
-        retryTask.originalTask = networkService.request(resource, onCompletion: onCompletion, onError: retryTask.createOnError())
+        retryTask.originalTask = networkService.request(queue: queue, resource: resource, onCompletion: onCompletion, onError: retryTask.createOnError())
         
         return retryTask
     }

--- a/Source/RetryNetworkService.swift
+++ b/Source/RetryNetworkService.swift
@@ -61,15 +61,15 @@ public final class RetryNetworkService: NetworkServiceProviding {
     }
     
     @discardableResult
-    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletion: @escaping (T.Model, HTTPURLResponse) -> Void,
+    public func request<T: ResourceModeling>(queue: DispatchQueue, resource: T, onCompletionWithResponse: @escaping (T.Model, HTTPURLResponse) -> Void,
                         onError: @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting {
         let retryTask = RetryNetworkTask(maxmimumNumberOfRetries: numberOfRetries, idleTimeInterval: idleTimeInterval, shouldRetry: shouldRetry,
-                                  onSuccess: onCompletion, onError: onError, retryAction: { completion, error in
-                                    return self.networkService.request(queue: queue, resource: resource, onCompletion: completion, onError: error)
+                                  onSuccess: onCompletionWithResponse, onError: onError, retryAction: { completion, error in
+                                    return self.networkService.request(queue: queue, resource: resource, onCompletionWithResponse: completion, onError: error)
         }, dispatchRetry: { [weak self] disptachTime, block in
             self?.dispatchRetry(disptachTime, block)
         })
-        retryTask.originalTask = networkService.request(queue: queue, resource: resource, onCompletion: onCompletion, onError: retryTask.createOnError())
+        retryTask.originalTask = networkService.request(queue: queue, resource: resource, onCompletionWithResponse: onCompletionWithResponse, onError: retryTask.createOnError())
         
         return retryTask
     }

--- a/Source/RetryNetworkService.swift
+++ b/Source/RetryNetworkService.swift
@@ -69,7 +69,8 @@ public final class RetryNetworkService: NetworkServiceProviding {
         }, dispatchRetry: { [weak self] disptachTime, block in
             self?.dispatchRetry(disptachTime, block)
         })
-        retryTask.originalTask = networkService.request(queue: queue, resource: resource, onCompletionWithResponse: onCompletionWithResponse, onError: retryTask.createOnError())
+        retryTask.originalTask = networkService.request(queue: queue, resource: resource,
+                                                        onCompletionWithResponse: onCompletionWithResponse, onError: retryTask.createOnError())
         
         return retryTask
     }

--- a/Source/RetryNetworkTask.swift
+++ b/Source/RetryNetworkTask.swift
@@ -37,11 +37,11 @@ class RetryNetworkTask<T> : NetworkTaskRepresenting {
     var originalTask: NetworkTaskRepresenting?
     
     private var numberOfRetriesLeft: Int
-    private let onSuccess: ((T) -> Void)
+    private let onSuccess: ((T, HTTPURLResponse) -> Void)
     private let onError: ((DBNetworkStackError) -> Void)
     private var isCaneled = false
     
-    private let retryAction: (@escaping (T) -> Void, @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting
+    private let retryAction: (@escaping (T, HTTPURLResponse) -> Void, @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting
     private let dispatchRetry: (_ deadline: DispatchTime, _ execute: @escaping () -> Void ) -> Void
     
     /// Creates an instance of `RetryNetworkTaks`
@@ -54,9 +54,9 @@ class RetryNetworkTask<T> : NetworkTaskRepresenting {
     ///   - onError: closure which gets fired on error
     ///   - retryAction: closure which gets triggerd when retry starts
     ///   - dispatchRetry: location where to dispatch the retry action
-    init(maxmimumNumberOfRetries: Int, idleTimeInterval: TimeInterval, shouldRetry: @escaping (DBNetworkStackError) -> Bool, onSuccess: @escaping (T) -> Void,
+    init(maxmimumNumberOfRetries: Int, idleTimeInterval: TimeInterval, shouldRetry: @escaping (DBNetworkStackError) -> Bool, onSuccess: @escaping (T, HTTPURLResponse) -> Void,
          onError: @escaping (DBNetworkStackError) -> Void,
-         retryAction: @escaping (@escaping (T) -> Void, @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting,
+         retryAction: @escaping (@escaping (T, HTTPURLResponse) -> Void, @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting,
          dispatchRetry: @escaping (_ deadline: DispatchTime, _ execute: @escaping () -> Void) -> Void ) {
         
         self.maxmimumNumberOfRetries = maxmimumNumberOfRetries

--- a/Source/RetryNetworkTask.swift
+++ b/Source/RetryNetworkTask.swift
@@ -54,7 +54,8 @@ class RetryNetworkTask<T> : NetworkTaskRepresenting {
     ///   - onError: closure which gets fired on error
     ///   - retryAction: closure which gets triggerd when retry starts
     ///   - dispatchRetry: location where to dispatch the retry action
-    init(maxmimumNumberOfRetries: Int, idleTimeInterval: TimeInterval, shouldRetry: @escaping (DBNetworkStackError) -> Bool, onSuccess: @escaping (T, HTTPURLResponse) -> Void,
+    init(maxmimumNumberOfRetries: Int, idleTimeInterval: TimeInterval, shouldRetry: @escaping (DBNetworkStackError) -> Bool,
+         onSuccess: @escaping (T, HTTPURLResponse) -> Void,
          onError: @escaping (DBNetworkStackError) -> Void,
          retryAction: @escaping (@escaping (T, HTTPURLResponse) -> Void, @escaping (DBNetworkStackError) -> Void) -> NetworkTaskRepresenting,
          dispatchRetry: @escaping (_ deadline: DispatchTime, _ execute: @escaping () -> Void) -> Void ) {

--- a/Source/URLRequestConvertible.swift
+++ b/Source/URLRequestConvertible.swift
@@ -66,7 +66,7 @@ extension URL {
             urlComponents.percentEncodedQuery = percentEncodedQuery.joined(separator: "&")
             
             guard let absoluteURL = urlComponents.url else {
-                fatalError("Error createing absolute URL from path: \(path), with baseURL: \(baseURL)")
+                fatalError("Error createing absolute URL from path: \(String(describing: path)), with baseURL: \(String(describing: baseURL))")
             }
             return absoluteURL
         }

--- a/Tests/DBNetworkStackTests/DefaultMocks.swift
+++ b/Tests/DBNetworkStackTests/DefaultMocks.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright (C) 2017 Lukas Schmidt.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a 
+//  copy of this software and associated documentation files (the "Software"), 
+//  to deal in the Software without restriction, including without limitation 
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+//  and/or sell copies of the Software, and to permit persons to whom the 
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in 
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//  DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+
+extension URL {
+    static let defaultMock: URL = URL(string: "bahn.de")!
+}
+
+extension URLRequest {
+    static let defaultMock: URLRequest = URLRequest(url: .defaultMock)
+}
+
+extension HTTPURLResponse {
+    static let defaultMock = HTTPURLResponse(url: .defaultMock, mimeType: nil, expectedContentLength: 1, textEncodingName: nil)
+}

--- a/Tests/DBNetworkStackTests/NetworkServiceTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceTest.swift
@@ -61,7 +61,7 @@ class NetworkServiceTest: XCTestCase {
     
     func testRequest_withValidResponse() {
         //Given
-        networkAccess.changeMock(data: Train.validJSONData, response: nil, error: nil)
+        networkAccess.changeMock(data: Train.validJSONData, response: .defaultTestResponse, error: nil)
         let expection = expectation(description: "loadValidRequest")
         
         //When

--- a/Tests/DBNetworkStackTests/NetworkServiceTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceTest.swift
@@ -157,7 +157,7 @@ class NetworkServiceTest: XCTestCase {
             }, onError: { resultError in
                 //Then
                 switch resultError {
-                case .requestError(_):
+                case .requestError:
                     //XCTAssertEqual(err as NSError, error)
                     expection.fulfill()
                 default:

--- a/Tests/DBNetworkStackTests/NetworkServiceTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceTest.swift
@@ -65,7 +65,7 @@ class NetworkServiceTest: XCTestCase {
         let expection = expectation(description: "loadValidRequest")
         
         //When
-        networkService.request(resource: resource, onCompletion: { train, response in
+        networkService.request(resource, onCompletionWithResponse: { train, response in
             XCTAssertEqual(train.name, self.trainName)
             XCTAssertEqual(response, .defaultMock)
             expection.fulfill()

--- a/Tests/DBNetworkStackTests/NetworkServiceTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceTest.swift
@@ -158,7 +158,6 @@ class NetworkServiceTest: XCTestCase {
                 //Then
                 switch resultError {
                 case .requestError:
-                    //XCTAssertEqual(err as NSError, error)
                     expection.fulfill()
                 default:
                     XCTFail()

--- a/Tests/DBNetworkStackTests/NetworkServiceTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceTest.swift
@@ -61,13 +61,13 @@ class NetworkServiceTest: XCTestCase {
     
     func testRequest_withValidResponse() {
         //Given
-        networkAccess.changeMock(data: Train.validJSONData, response: .defaultTestResponse, error: nil)
+        networkAccess.changeMock(data: Train.validJSONData, response: .defaultMock, error: nil)
         let expection = expectation(description: "loadValidRequest")
         
         //When
         networkService.request(resource: resource, onCompletion: { train, response in
             XCTAssertEqual(train.name, self.trainName)
-            XCTAssertEqual(response, .defaultTestResponse)
+            XCTAssertEqual(response, .defaultMock)
             expection.fulfill()
             }, onError: { _ in
                 XCTFail()
@@ -85,21 +85,27 @@ class NetworkServiceTest: XCTestCase {
         let expection = expectation(description: "testNoData")
         
         //When
+        var capturedError: DBNetworkStackError?
         networkService.request(resource, onCompletion: { _ in
             XCTFail()
             }, onError: { error in
-                switch error {
-                case .serializationError(let description, let data):
-                    XCTAssertEqual("No data to serialize revied from the server", description)
-                    XCTAssertNil(data)
-                    expection.fulfill()
-                default:
-                    XCTFail()
-                }
+                capturedError = error
+                expection.fulfill()
         })
         
         //Then
         waitForExpectations(timeout: 1, handler: nil)
+        guard let error = capturedError else {
+            XCTFail()
+            return
+        }
+        switch error {
+        case .serializationError(let description, let data):
+            XCTAssertEqual("No data to serialize revied from the server", description)
+            XCTAssertNil(data)
+        default:
+            XCTFail()
+        }
     }
     
     func testInvalidData() {

--- a/Tests/DBNetworkStackTests/NetworkServiceTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceTest.swift
@@ -65,8 +65,9 @@ class NetworkServiceTest: XCTestCase {
         let expection = expectation(description: "loadValidRequest")
         
         //When
-        networkService.request(resource, onCompletion: { train in
+        networkService.request(resource: resource, onCompletion: { train, response in
             XCTAssertEqual(train.name, self.trainName)
+            XCTAssertEqual(response, .defaultTestResponse)
             expection.fulfill()
             }, onError: { _ in
                 XCTFail()

--- a/Tests/DBNetworkStackTests/RetryNetworkserviceTest.swift
+++ b/Tests/DBNetworkStackTests/RetryNetworkserviceTest.swift
@@ -56,7 +56,7 @@ class RetryNetworkserviceTest: XCTestCase {
                                    idleTimeInterval: 0, shouldRetry: { _ in return true}, dispatchRetry: { _, block in
             executedRetrys += 1
             block()
-        }).request(resource: resource, onCompletion: { _, _ in
+        }).request(resource, onCompletionWithResponse: { _, _ in
         }, onError: { _ in
             XCTFail()
         })

--- a/Tests/DBNetworkStackTests/RetryNetworkserviceTest.swift
+++ b/Tests/DBNetworkStackTests/RetryNetworkserviceTest.swift
@@ -56,7 +56,7 @@ class RetryNetworkserviceTest: XCTestCase {
                                    idleTimeInterval: 0, shouldRetry: { _ in return true}, dispatchRetry: { _, block in
             executedRetrys += 1
             block()
-        }).request(resource, onCompletion: { _ in
+        }).request(resource: resource, onCompletion: { _, _ in
         }, onError: { _ in
             XCTFail()
         })

--- a/Tests/DBNetworkStackTests/RetryTaskTest.swift
+++ b/Tests/DBNetworkStackTests/RetryTaskTest.swift
@@ -27,10 +27,6 @@ import Foundation
 import XCTest
 @testable import DBNetworkStack
 
-extension HTTPURLResponse {
-    static let defaultTestResponse = HTTPURLResponse(url: URL(string: "bahn.de")!, mimeType: nil, expectedContentLength: 1, textEncodingName: nil)
-}
-
 class RetryTaskTest: XCTestCase {
     
     let mockError: DBNetworkStackError = .unknownError
@@ -59,7 +55,7 @@ class RetryTaskTest: XCTestCase {
             successValue = value
         }, onError: { _ in
         }, retryAction: {sucess, _ in
-            sucess(0, .defaultTestResponse)
+            sucess(0, .defaultMock)
             return NetworkTaskMock()
         }, dispatchRetry: { _, block in
             block()
@@ -87,7 +83,7 @@ class RetryTaskTest: XCTestCase {
         }, retryAction: {success, error in
             numerOfRertrys += 1
             if numerOfRertrys == 3 {
-                success(0, .defaultTestResponse)
+                success(0, .defaultMock)
             } else {
                error(self.mockError)
             }
@@ -119,7 +115,7 @@ class RetryTaskTest: XCTestCase {
         }, retryAction: { onSucess, onError in
             numerOfRertrys += 1
             if numerOfRertrys == 3 {
-                onSucess(0, .defaultTestResponse)
+                onSucess(0, .defaultMock)
             } else {
                 onError(self.mockError)
             }

--- a/Tests/DBNetworkStackTests/RetryTaskTest.swift
+++ b/Tests/DBNetworkStackTests/RetryTaskTest.swift
@@ -27,6 +27,10 @@ import Foundation
 import XCTest
 @testable import DBNetworkStack
 
+extension HTTPURLResponse {
+    static let defaultTestResponse = HTTPURLResponse(url: URL(string: "bahn.de")!, mimeType: nil, expectedContentLength: 1, textEncodingName: nil)
+}
+
 class RetryTaskTest: XCTestCase {
     
     let mockError: DBNetworkStackError = .unknownError
@@ -51,11 +55,11 @@ class RetryTaskTest: XCTestCase {
         //Given
         var successValue: Int?
         var task: RetryNetworkTask<Int>? = RetryNetworkTask(maxmimumNumberOfRetries: 1, idleTimeInterval: 1,
-                                                            shouldRetry: { _ in return true}, onSuccess: { (value: Int) in
+                                                            shouldRetry: { _ in return true}, onSuccess: { (value: Int, _) in
             successValue = value
         }, onError: { _ in
         }, retryAction: {sucess, _ in
-            sucess(0)
+            sucess(0, .defaultTestResponse)
             return NetworkTaskMock()
         }, dispatchRetry: { _, block in
             block()
@@ -78,12 +82,12 @@ class RetryTaskTest: XCTestCase {
         //Given
         var numerOfRertrys = 0
         var task: RetryNetworkTask<Int>? = RetryNetworkTask(maxmimumNumberOfRetries: 3, idleTimeInterval: 0.3,
-                                                            shouldRetry: { _ in return true}, onSuccess: { (_: Int) in
+                                                            shouldRetry: { _ in return true}, onSuccess: { (_: Int, _) in
         }, onError: { _ in
         }, retryAction: {success, error in
             numerOfRertrys += 1
             if numerOfRertrys == 3 {
-                success(0)
+                success(0, .defaultTestResponse)
             } else {
                error(self.mockError)
             }
@@ -110,12 +114,12 @@ class RetryTaskTest: XCTestCase {
     func testDontHoldReference_CancleTask() {
         var numerOfRertrys = 0
         var task: RetryNetworkTask<Int>? = RetryNetworkTask(maxmimumNumberOfRetries: 3, idleTimeInterval: 0.3,
-                                                            shouldRetry: { _ in return true}, onSuccess: { (_: Int) in
+                                                            shouldRetry: { _ in return true}, onSuccess: { (_: Int, _) in
         }, onError: { _ in
         }, retryAction: { onSucess, onError in
             numerOfRertrys += 1
             if numerOfRertrys == 3 {
-                onSucess(0)
+                onSucess(0, .defaultTestResponse)
             } else {
                 onError(self.mockError)
             }


### PR DESCRIPTION
Fixes issues:  #49 , #39

New feature:
When doing a network request, you may want to access the raw HTTPResponse. In our current implementation is this not possible. This opens up the API to access the HTTPResponse when needed.

#### Make sure to check all boxes before merging

- [x] Method/Class documentation
- [x] README.md documentation
- [x] Unit tests for new features/regressions