### PR TITLE
Feature/fixes network service mock return execusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ matrix:
       script:
         - swift test --verbose
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.1
       language: objective-c
       env: "macOS"
       script:
         - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination 'platform=OS X' test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -enableCodeCoverage NO | xcpretty
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.1
       language: objective-c
       env: "iOS"
       script:
@@ -31,19 +31,19 @@ matrix:
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.1
       language: objective-c
       env: "watchOS"
       script:
         - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination 'platform=watchOS Simulator,name=Apple Watch Series 2 - 38mm' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.1
       language: objective-c
       env: "tvOS"
       script:
         - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=latest' test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -enableCodeCoverage NO | xcpretty
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.1
       language: objective-c
       env: "SPM, Carthage, CocoaPods"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,9 @@ matrix:
       language: objective-c
       env: "macOS"
       script:
-        - carthage bootstrap
-        - set -o pipefail && xcodebuild -scheme DBNetworkStackSourcing -destination "platform=tvOS Simulator,name=Apple TV 1080p" test | xcpretty
-        - set -o pipefail && xcodebuild -scheme DBNetworkStackSourcing -destination "platform=watchOS Simulator,name=Apple Watch - 38mm" build | xcpretty
-        - set -o pipefail && xcodebuild -scheme DBNetworkStackSourcing -destination "platform=iOS Simulator,name=iPhone SE" test | xcpretty
+        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=tvOS Simulator,name=Apple TV 1080p" test | xcpretty
+        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=watchOS Simulator,name=Apple Watch - 38mm" build | xcpretty
+        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=iOS Simulator,name=iPhone SE" test | xcpretty
         - swift test & pod spec lint & carthage build --no-skip-current
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ matrix:
       language: objective-c
       env: "macOS"
       script:
-        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=tvOS Simulator,name=Apple TV 1080p" test | xcpretty
+        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=tvOS Simulator,name=OS X" test | xcpretty
+        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=tvOS Simulator,name=Apple TV" test | xcpretty
         - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=watchOS Simulator,name=Apple Watch - 38mm" build | xcpretty
         - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=iOS Simulator,name=iPhone SE" test | xcpretty
-        - swift test & pod spec lint & carthage build --no-skip-current
+        - swift test & pod spec lint --allow-warnings & carthage build --no-skip-current
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       language: objective-c
       env: "macOS"
       script:
-        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=tvOS Simulator,name=OS X" test | xcpretty
+        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=macOS" test | xcpretty
         - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=tvOS Simulator,name=Apple TV" test | xcpretty
         - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=watchOS Simulator,name=Apple Watch - 38mm" build | xcpretty
         - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination "platform=iOS Simulator,name=iPhone SE" test | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
       before_install:
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
         - cd ..
-        - export SWIFT_VERSION=swift-4.0-RELEASE
-        - wget https://swift.org/builds/swift-3.1-release/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz
+        - export SWIFT_VERSION=swift-4.0.2-RELEASE
+        - wget https://swift.org/builds/swift-4.0.2-release/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz
         - tar xzf $SWIFT_VERSION-ubuntu14.04.tar.gz
         - export PATH="${PWD}/${SWIFT_VERSION}-ubuntu14.04/usr/bin:${PATH}"
         - cd DBNetworkStack
@@ -21,30 +21,10 @@ matrix:
       language: objective-c
       env: "macOS"
       script:
-        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination 'platform=OS X' test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -enableCodeCoverage NO | xcpretty
-    - os: osx
-      osx_image: xcode9.1
-      language: objective-c
-      env: "iOS"
-      script:
-        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination 'platform=iOS Simulator,name=iPhone SE,OS=latest' test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -enableCodeCoverage YES | xcpretty
+        - carthage bootstrap
+        - set -o pipefail && xcodebuild -scheme DBNetworkStackSourcing -destination "platform=tvOS Simulator,name=Apple TV 1080p" test | xcpretty
+        - set -o pipefail && xcodebuild -scheme DBNetworkStackSourcing -destination "platform=watchOS Simulator,name=Apple Watch - 38mm" build | xcpretty
+        - set -o pipefail && xcodebuild -scheme DBNetworkStackSourcing -destination "platform=iOS Simulator,name=iPhone SE" test | xcpretty
+        - swift test & pod spec lint & carthage build --no-skip-current
       after_success:
         - bash <(curl -s https://codecov.io/bash)
-    - os: osx
-      osx_image: xcode9.1
-      language: objective-c
-      env: "watchOS"
-      script:
-        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination 'platform=watchOS Simulator,name=Apple Watch Series 2 - 38mm' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
-    - os: osx
-      osx_image: xcode9.1
-      language: objective-c
-      env: "tvOS"
-      script:
-        - set -o pipefail && xcodebuild -scheme DBNetworkStack -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=latest' test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -enableCodeCoverage NO | xcpretty
-    - os: osx
-      osx_image: xcode9.1
-      language: objective-c
-      env: "SPM, Carthage, CocoaPods"
-      script:
-        - swift test & pod spec lint & carthage build --no-skip-current

--- a/DBNetworkStack.podspec
+++ b/DBNetworkStack.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "DBNetworkStack"
-  s.version      = "0.5.0"
+  s.version      = "0.7"
   s.summary      = "DBNetworkStack is a network abstraction for fetching request and mapping them to model objects."
 
   # This description is used to generate tags and improve search results.
@@ -27,7 +27,6 @@ Pod::Spec.new do |s|
   s.description  = "DBNetworkStack is a network abstraction for fetching request and mapping them to model objects. It supports mocking via protocols."
 
   s.homepage     = "https://github.com/dbsystel/DBNetworkStack"
-  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
 
 
   # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/Source/NetworkServiceMock.swift
+++ b/Source/NetworkServiceMock.swift
@@ -74,7 +74,7 @@ public class NetworkServiceMock: NetworkServiceProviding {
     ///   - error: the error which gets passed to the caller
     ///   - count: the count, how often the error accours. 1 by default
     public func returnError(with error: NetworkError, count: Int = 1) {
-        for _ in 0...count {
+        for _ in 0..<count {
             onErrorCallback?(error)
         }
        releaseCapturedCallbacks()
@@ -87,7 +87,7 @@ public class NetworkServiceMock: NetworkServiceProviding {
     ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
     ///   - count: the count how often the response gets triggerd. 1 by default
     public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int = 1) {
-        for _ in 0...count {
+        for _ in 0..<count {
             onSuccess?(data, httpResponse)
         }
         releaseCapturedCallbacks()
@@ -102,7 +102,7 @@ public class NetworkServiceMock: NetworkServiceProviding {
     ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
     ///   - count: the count how often the response gets triggerd. 1 by default
     public func returnSuccess<T>(with serializedResponse: T, httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int = 1) {
-        for _ in 0...count {
+        for _ in 0..<count {
             onTypedSuccess?(serializedResponse, httpResponse)
         }
         releaseCapturedCallbacks()

--- a/Tests/DBNetworkStackTests/NetworkErrorTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkErrorTest.swift
@@ -149,7 +149,7 @@ class NetworkErrorTest: XCTestCase {
         
         //Then
         XCTAssert(debugDescription.hasPrefix("Authorization error: <NSHTTPURLResponse: "))
-        XCTAssert(debugDescription.hasSuffix("> { URL: https://bahn.de } { Status Code: 0, Headers {\n} }, response: dataString"))
+        XCTAssert(debugDescription.hasSuffix("response: dataString"))
     }
     
     func testUnknownError_clientError_description() {
@@ -163,7 +163,7 @@ class NetworkErrorTest: XCTestCase {
         
         //Then
         XCTAssert(debugDescription.hasPrefix("Client error: <NSHTTPURLResponse: "))
-        XCTAssert(debugDescription.hasSuffix("> { URL: https://bahn.de } { Status Code: 0, Headers {\n} }, response: dataString"))
+        XCTAssert(debugDescription.hasSuffix("response: dataString"))
     }
     
     func testUnknownError_serializationError_description() {

--- a/Tests/DBNetworkStackTests/NetworkErrorTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkErrorTest.swift
@@ -149,7 +149,7 @@ class NetworkErrorTest: XCTestCase {
         
         //Then
         XCTAssert(debugDescription.hasPrefix("Authorization error: <NSHTTPURLResponse: "))
-        XCTAssert(debugDescription.hasSuffix("> { URL: https://bahn.de } { status code: 0, headers {\n} }, response: dataString"))
+        XCTAssert(debugDescription.hasSuffix("> { URL: https://bahn.de } { Status Code: 0, Headers {\n} }, response: dataString"))
     }
     
     func testUnknownError_clientError_description() {
@@ -163,7 +163,7 @@ class NetworkErrorTest: XCTestCase {
         
         //Then
         XCTAssert(debugDescription.hasPrefix("Client error: <NSHTTPURLResponse: "))
-        XCTAssert(debugDescription.hasSuffix("> { URL: https://bahn.de } { status code: 0, headers {\n} }, response: dataString"))
+        XCTAssert(debugDescription.hasSuffix("> { URL: https://bahn.de } { Status Code: 0, Headers {\n} }, response: dataString"))
     }
     
     func testUnknownError_serializationError_description() {

--- a/Tests/DBNetworkStackTests/NetworkServiceMockTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceMockTest.swift
@@ -48,51 +48,56 @@ class NetworkServiceMockTest: XCTestCase {
     func testReturnSuccessWithData() {
         //Given
         var capturedResult: Int?
+        var executionCount: Int = 0
         
         //When
         networkServiceMock.request(resource, onCompletion: { result in
             capturedResult = result
+            executionCount += 1
         }, onError: { _ in })
         networkServiceMock.returnSuccess()
         
         //Then
         XCTAssertEqual(capturedResult, 1)
+        XCTAssertEqual(executionCount, 1)
     }
     
     func testReturnSuccessWithSerializedData() {
         //Given
         var capturedResult: Int?
+        var executionCount: Int = 0
         
         //When
         networkServiceMock.request(resource, onCompletion: { result in
             capturedResult = result
+            executionCount += 1
         }, onError: { _ in })
         networkServiceMock.returnSuccess(with: 10)
         
         //Then
         XCTAssertEqual(capturedResult, 10)
+        XCTAssertEqual(executionCount, 1)
     }
     
     func testReturnError() {
         //Given
         var capturedError: NetworkError?
+        var executionCount: Int = 0
         
         //When
         networkServiceMock.request(resource, onCompletion: { _ in }, onError: { error in
             capturedError = error
+            executionCount += 1
         })
         networkServiceMock.returnError(with: .unknownError)
         
         //Then
-        guard let error = capturedError else {
-             XCTFail()
-            return
-        }
-        if case .unknownError = error {
+        if let error = capturedError, case .unknownError = error {
             
         } else {
-            XCTFail()
+            XCTFail("Wrong error type")
         }
+        XCTAssertEqual(executionCount, 1)
     }
     
 }

--- a/Tests/DBNetworkStackTests/RetryNetworkserviceTest.swift
+++ b/Tests/DBNetworkStackTests/RetryNetworkserviceTest.swift
@@ -47,7 +47,7 @@ class RetryNetworkserviceTest: XCTestCase {
     func testRetryRequest_shouldRetry() {
         //Given
         let errorCount = 2
-        let numberOfRetries = 3
+        let numberOfRetries = 2
         var executedRetrys = 0
         
         //When


### PR DESCRIPTION
Fixes issues: 
#63 ,
When mocking a returning result with `NetworkServiceMock` you expect a single call of success or error block.

At the moment the success or error block is called n+1 which is wrong.


#### Make sure to check all boxes before merging

- [x] Method/Class documentation
- [x] README.md documentation
- [x] Unit tests for new features/regressions