### PR TITLE
Added public protection level to initializer of NetworkError.

### DIFF
--- a/Source/NetworkError.swift
+++ b/Source/NetworkError.swift
@@ -40,7 +40,7 @@ public enum NetworkError: Error {
     /// Complete request failed.
     case requestError(error: Error)
     
-    init?(response: HTTPURLResponse?, data: Data?) {
+    public init?(response: HTTPURLResponse?, data: Data?) {
         guard let response = response else {
             return nil
         }


### PR DESCRIPTION
Added public protection level to initializer of NetworkError. This way, NetworkError can be used in Unit-Tests without building the framework with debug configuration.
