### PR TITLE
Update NetworkServiceMock.swift

### DIFF
--- a/Source/NetworkServiceMock.swift
+++ b/Source/NetworkServiceMock.swift
@@ -126,7 +126,7 @@ public final class NetworkServiceMock: NetworkService {
     /// - Parameters:
     ///   - error: the error which gets passed to the caller
     public func returnError(with error: NetworkError) {
-        returnError(with: error, count: 1)
+        callbacks.removeFirst().onErrorCallback?(error)
     }
     
     /// Will return an error to the current waiting request.
@@ -138,7 +138,7 @@ public final class NetworkServiceMock: NetworkService {
     public func returnError(with error: NetworkError, count: Int) {
         (0..<count).forEach { _ in
             precondition(!callbacks.isEmpty, "There is no request left to return an error for.")
-            callbacks.removeFirst().onErrorCallback?(error)
+            returnError(with: error)
         }
     }
     
@@ -148,7 +148,7 @@ public final class NetworkServiceMock: NetworkService {
     ///   - data: the mock response from the server. `Data()` by default
     ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
     public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse()) {
-        returnSuccess(with: data, httpResponse: httpResponse, count: 1)
+        callbacks.removeFirst().onSuccess?(data, httpResponse)
     }
     
     /// Will return a successful request, by using the given data as a server response.
@@ -161,7 +161,7 @@ public final class NetworkServiceMock: NetworkService {
     public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int) {
         (0..<count).forEach { _ in
             precondition(!callbacks.isEmpty, "There is no request left to return a success for.")
-            callbacks.removeFirst().onSuccess?(data, httpResponse)
+            returnSuccess(with: data, httpResponse: httpResponse)
         }
     }
     
@@ -173,7 +173,7 @@ public final class NetworkServiceMock: NetworkService {
     ///   - data: the mock response from the server. `Data()` by default
     ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
     public func returnSuccess<T>(with serializedResponse: T, httpResponse: HTTPURLResponse = HTTPURLResponse()) {
-        returnSuccess(with: serializedResponse, httpResponse: httpResponse, count: 1)
+        callbacks.removeFirst().onTypedSuccess?(serializedResponse, httpResponse)
     }
     
     /// Will return a successful request, by using the given type `T` as serialized result of a request.
@@ -188,7 +188,7 @@ public final class NetworkServiceMock: NetworkService {
     public func returnSuccess<T>(with serializedResponse: T, httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int) {
         (0..<count).forEach { _ in
             precondition(!callbacks.isEmpty, "There is no request left to return a typed success for.")
-            callbacks.removeFirst().onTypedSuccess?(serializedResponse, httpResponse)
+            returnSuccess(with: serializedResponse, httpResponse: httpResponse)
         }
     }
     

--- a/Source/NetworkServiceMock.swift
+++ b/Source/NetworkServiceMock.swift
@@ -59,8 +59,41 @@ struct NetworkServiceMockCallback {
  
  //When
  // Your test code
+ networkService.request(
+    resource,
+    onCompletion: { string in /*...*/ },
+    onError: { error in /*...*/ }
+ )
  networkService.returnSuccess(with: "Sucess")
  
+ //Then
+ //Test your expectations
+ 
+ ```
+
+ It is possible to start multiple requests at a time. All requests and responses (or errors) are processed in order they have been called. So, everything is serial.
+
+ **Example**:
+ ```swift
+ //Given
+ let networkServiceMock = NetworkServiceMock()
+ let resource: Resource<String> = //
+ 
+ //When
+ networkService.request(
+    resource,
+    onCompletion: { string in /* Success */ },
+    onError: { error in /*...*/ }
+ )
+ networkService.request(
+    resource,
+    onCompletion: { string in /*...*/ },
+    onError: { error in /*. cancel error .*/ }
+ )
+
+ networkService.returnSuccess(with: "Sucess")
+ networkService.returnError(with: .cancelled)
+
  //Then
  //Test your expectations
  

--- a/Source/NetworkServiceMock.swift
+++ b/Source/NetworkServiceMock.swift
@@ -145,9 +145,9 @@ public final class NetworkServiceMock: NetworkService {
     /// Will return a successful request, by using the given data as a server response.
     ///
     /// - Parameters:
-    ///   - data: the mock response from the server. `Data()` by default
+    ///   - data: the mock response from the server.
     ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
-    public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse()) {
+    public func returnSuccess(with data: Data, httpResponse: HTTPURLResponse = HTTPURLResponse()) {
         callbacks.removeFirst().onSuccess?(data, httpResponse)
     }
     
@@ -158,7 +158,7 @@ public final class NetworkServiceMock: NetworkService {
     ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
     ///   - count: the count how often the response gets triggerd.
     @available(*, deprecated, message: "Use returnSuccess without count parameter instead. Multiple calls can be done manually.")
-    public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int) {
+    public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int = 1) {
         (0..<count).forEach { _ in
             precondition(!callbacks.isEmpty, "There is no request left to return a success for.")
             returnSuccess(with: data, httpResponse: httpResponse)

--- a/Source/NetworkServiceMock.swift
+++ b/Source/NetworkServiceMock.swift
@@ -49,7 +49,8 @@ struct NetworkServiceMockCallback {
 }
 
 /**
- Mocks a `NetworkService`. You can configure expected results or errors to have a fully functional mock.
+ Mocks a `NetworkService`.
+ You can configure expected results or errors to have a fully functional mock.
  
  **Example**:
  ```swift
@@ -58,7 +59,6 @@ struct NetworkServiceMockCallback {
  let resource: Resource<String> = //
  
  //When
- // Your test code
  networkService.request(
     resource,
     onCompletion: { string in /*...*/ },
@@ -71,7 +71,9 @@ struct NetworkServiceMockCallback {
  
  ```
 
- It is possible to start multiple requests at a time. All requests and responses (or errors) are processed in order they have been called. So, everything is serial.
+ It is possible to start multiple requests at a time.
+ All requests and responses (or errors) are processed
+ in order they have been called. So, everything is serial.
 
  **Example**:
  ```swift

--- a/Source/NetworkServiceMock.swift
+++ b/Source/NetworkServiceMock.swift
@@ -76,11 +76,11 @@ public final class NetworkServiceMock: NetworkService {
     /// Set this to hava a custom networktask returned by the mock
     public var nextNetworkTask: NetworkTask?
     
-    private var callbacks: NetworkServiceMockCallback?
+    private var callbacks: [NetworkServiceMockCallback] = []
     
     /// Creates an instace of `NetworkServiceMock`
     public init() {}
-
+    
     /**
      Fetches a resource asynchronously from remote location. Execution of the requests starts immediately.
      Execution happens on no specific queue. It dependes on the network access which queue is used.
@@ -93,9 +93,9 @@ public final class NetworkServiceMock: NetworkService {
      let resource: Resource<String> = //
      
      networkService.request(queue: .main, resource: resource, onCompletionWithResponse: { htmlText, response in
-        print(htmlText, response)
+     print(htmlText, response)
      }, onError: { error in
-        // Handle errors
+     // Handle errors
      })
      ```
      
@@ -108,11 +108,15 @@ public final class NetworkServiceMock: NetworkService {
      */
     @discardableResult
     public func request<Result>(queue: DispatchQueue, resource: Resource<Result>, onCompletionWithResponse: @escaping (Result, HTTPURLResponse) -> Void,
-                 onError: @escaping (NetworkError) -> Void) -> NetworkTask {
-
+                                onError: @escaping (NetworkError) -> Void) -> NetworkTask {
+        
         lastRequest = resource.request
         requestCount += 1
-        callbacks = NetworkServiceMockCallback(resource: resource, onCompletionWithResponse: onCompletionWithResponse, onError: onError)
+        callbacks.append(NetworkServiceMockCallback(
+            resource: resource,
+            onCompletionWithResponse: onCompletionWithResponse,
+            onError: onError
+        ))
         
         return nextNetworkTask ?? NetworkTaskMock()
     }
@@ -121,12 +125,21 @@ public final class NetworkServiceMock: NetworkService {
     ///
     /// - Parameters:
     ///   - error: the error which gets passed to the caller
-    ///   - count: the count, how often the error accours. 1 by default
-    public func returnError(with error: NetworkError, count: Int = 1) {
-        for _ in 0..<count {
-            callbacks?.onErrorCallback?(error)
+    public func returnError(with error: NetworkError) {
+        returnError(with: error, count: 1)
+    }
+    
+    /// Will return an error to the current waiting request.
+    ///
+    /// - Parameters:
+    ///   - error: the error which gets passed to the caller
+    ///   - count: the count, how often the error occours.
+    @available(*, deprecated, message: "Use returnError without count parameter instead. Multiple calls can be done manually.")
+    public func returnError(with error: NetworkError, count: Int) {
+        (0..<count).forEach { _ in
+            precondition(!callbacks.isEmpty, "There is no request left to return an error for.")
+            callbacks.removeFirst().onErrorCallback?(error)
         }
-        callbacks = nil
     }
     
     /// Will return a successful request, by using the given data as a server response.
@@ -134,12 +147,22 @@ public final class NetworkServiceMock: NetworkService {
     /// - Parameters:
     ///   - data: the mock response from the server. `Data()` by default
     ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
-    ///   - count: the count how often the response gets triggerd. 1 by default
-    public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int = 1) {
-        for _ in 0..<count {
-            callbacks?.onSuccess?(data, httpResponse)
+    public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse()) {
+        returnSuccess(with: data, httpResponse: httpResponse, count: 1)
+    }
+    
+    /// Will return a successful request, by using the given data as a server response.
+    ///
+    /// - Parameters:
+    ///   - data: the mock response from the server. `Data()` by default
+    ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
+    ///   - count: the count how often the response gets triggerd.
+    @available(*, deprecated, message: "Use returnSuccess without count parameter instead. Multiple calls can be done manually.")
+    public func returnSuccess(with data: Data = Data(), httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int) {
+        (0..<count).forEach { _ in
+            precondition(!callbacks.isEmpty, "There is no request left to return a success for.")
+            callbacks.removeFirst().onSuccess?(data, httpResponse)
         }
-        callbacks = nil
     }
     
     /// Will return a successful request, by using the given type `T` as serialized result of a request.
@@ -149,12 +172,24 @@ public final class NetworkServiceMock: NetworkService {
     /// - Parameters:
     ///   - data: the mock response from the server. `Data()` by default
     ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
-    ///   - count: the count how often the response gets triggerd. 1 by default
-    public func returnSuccess<T>(with serializedResponse: T, httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int = 1) {
-        for _ in 0..<count {
-            callbacks?.onTypedSuccess?(serializedResponse, httpResponse)
+    public func returnSuccess<T>(with serializedResponse: T, httpResponse: HTTPURLResponse = HTTPURLResponse()) {
+        returnSuccess(with: serializedResponse, httpResponse: httpResponse, count: 1)
+    }
+    
+    /// Will return a successful request, by using the given type `T` as serialized result of a request.
+    ///
+    /// **Warning:** This will crash if type `T` does not match your expected ResponseType of your current request
+    ///
+    /// - Parameters:
+    ///   - data: the mock response from the server. `Data()` by default
+    ///   - httpResponse: the mock `HTTPURLResponse` from the server. `HTTPURLResponse()` by default
+    ///   - count: the count how often the response gets triggerd.
+    @available(*, deprecated, message: "Use returnSuccess without count parameter instead. Multiple calls can be done manually.")
+    public func returnSuccess<T>(with serializedResponse: T, httpResponse: HTTPURLResponse = HTTPURLResponse(), count: Int) {
+        (0..<count).forEach { _ in
+            precondition(!callbacks.isEmpty, "There is no request left to return a typed success for.")
+            callbacks.removeFirst().onTypedSuccess?(serializedResponse, httpResponse)
         }
-        callbacks = nil
     }
     
 }

--- a/Source/RetryNetworkTask.swift
+++ b/Source/RetryNetworkTask.swift
@@ -25,7 +25,7 @@ import Foundation
 import Dispatch
 
 /// A NetworkTaskRepresenting which can be used together with `RetryNetworkService` to keep a task alife to repeat the task after a given time
-class RetryNetworkTask<T> : NetworkTask {
+final class RetryNetworkTask<T> : NetworkTask {
     private let maxmimumNumberOfRetries: Int
     private let idleTimeInterval: TimeInterval
     private let shouldRetry: (NetworkError) -> Bool

--- a/Tests/DBNetworkStackTests/NetworkServiceMockTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceMockTest.swift
@@ -59,7 +59,6 @@ class NetworkServiceMockTest: XCTestCase {
         XCTAssertEqual(capturedResult, 1)
         XCTAssertEqual(executionCount, 1)
     }
-    
 
     func testCorrectOrderOfReturnSuccessWithDataForMultipleRequests() {
         //Given
@@ -67,12 +66,12 @@ class NetworkServiceMockTest: XCTestCase {
         var called2First = false
 
         //When
-        networkServiceMock.request(resource, onCompletion: { result in
+        networkServiceMock.request(resource, onCompletion: { _ in
             if !called2First {
                 called1First = true
             }
         }, onError: { _ in })
-        networkServiceMock.request(resource, onCompletion: { result in
+        networkServiceMock.request(resource, onCompletion: { _ in
             if !called1First {
                 called2First = true
             }
@@ -91,9 +90,9 @@ class NetworkServiceMockTest: XCTestCase {
         var executionCount2: Int = 0
 
         //When
-        networkServiceMock.request(resource, onCompletion: { result in
+        networkServiceMock.request(resource, onCompletion: { _ in
             executionCount1 += 1
-            self.networkServiceMock.request(self.resource, onCompletion: { result in
+            self.networkServiceMock.request(self.resource, onCompletion: { _ in
                 executionCount2 += 1
             }, onError: { _ in })
         }, onError: { _ in })
@@ -167,9 +166,9 @@ class NetworkServiceMockTest: XCTestCase {
         var executionCount2: Int = 0
         
         //When
-        networkServiceMock.request(resource, onCompletion: { result in
+        networkServiceMock.request(resource, onCompletion: { _ in
             executionCount1 += 1
-            self.networkServiceMock.request(self.resource, onCompletion: { result in
+            self.networkServiceMock.request(self.resource, onCompletion: { _ in
                 executionCount2 += 1
             }, onError: { _ in })
         }, onError: { _ in })

--- a/Tests/DBNetworkStackTests/NetworkServiceMockTest.swift
+++ b/Tests/DBNetworkStackTests/NetworkServiceMockTest.swift
@@ -60,6 +60,70 @@ class NetworkServiceMockTest: XCTestCase {
         XCTAssertEqual(executionCount, 1)
     }
     
+
+    func testCorrectOrderOfReturnSuccessWithDataForMultipleRequests() {
+        //Given
+        var called1First = false
+        var called2First = false
+
+        //When
+        networkServiceMock.request(resource, onCompletion: { result in
+            if !called2First {
+                called1First = true
+            }
+        }, onError: { _ in })
+        networkServiceMock.request(resource, onCompletion: { result in
+            if !called1First {
+                called2First = true
+            }
+        }, onError: { _ in })
+        networkServiceMock.returnSuccess()
+        networkServiceMock.returnSuccess()
+
+        //Then
+        XCTAssertTrue(called1First)
+        XCTAssertFalse(called2First)
+    }
+
+    func testRequestSuccessWithDataChaining() {
+        //Given
+        var executionCount1: Int = 0
+        var executionCount2: Int = 0
+
+        //When
+        networkServiceMock.request(resource, onCompletion: { result in
+            executionCount1 += 1
+            self.networkServiceMock.request(self.resource, onCompletion: { result in
+                executionCount2 += 1
+            }, onError: { _ in })
+        }, onError: { _ in })
+        networkServiceMock.returnSuccess()
+        networkServiceMock.returnSuccess()
+
+        //Then
+        XCTAssertEqual(executionCount1, 1)
+        XCTAssertEqual(executionCount2, 1)
+    }
+
+    func testReturnSuccessWithDataForAllRequests() {
+        //Given
+        var executionCount1: Int = 0
+        var executionCount2: Int = 0
+
+        //When
+        networkServiceMock.request(resource, onCompletion: { _ in
+            executionCount1 += 1
+        }, onError: { _ in })
+        networkServiceMock.request(resource, onCompletion: { _ in
+            executionCount2 += 1
+        }, onError: { _ in })
+        networkServiceMock.returnSuccess(count: 2)
+
+        //Then
+        XCTAssertEqual(executionCount1, 1)
+        XCTAssertEqual(executionCount2, 1)
+    }
+    
     func testReturnSuccessWithSerializedData() {
         //Given
         var capturedResult: Int?
@@ -75,6 +139,65 @@ class NetworkServiceMockTest: XCTestCase {
         //Then
         XCTAssertEqual(capturedResult, 10)
         XCTAssertEqual(executionCount, 1)
+    }
+    
+    func testCorrectOrderOfReturnSuccessWithSerializedDataForMultipleRequests() {
+        //Given
+        var capturedResult1: Int?
+        var capturedResult2: Int?
+
+        //When
+        networkServiceMock.request(resource, onCompletion: { result in
+            capturedResult1 = result
+        }, onError: { _ in })
+        networkServiceMock.request(resource, onCompletion: { result in
+            capturedResult2 = result
+        }, onError: { _ in })
+        networkServiceMock.returnSuccess(with: 10)
+        networkServiceMock.returnSuccess(with: 20)
+        
+        //Then
+        XCTAssertEqual(capturedResult1, 10)
+        XCTAssertEqual(capturedResult2, 20)
+    }
+    
+    func testRequestSuccessWithSerializedDataChaining() {
+        //Given
+        var executionCount1: Int = 0
+        var executionCount2: Int = 0
+        
+        //When
+        networkServiceMock.request(resource, onCompletion: { result in
+            executionCount1 += 1
+            self.networkServiceMock.request(self.resource, onCompletion: { result in
+                executionCount2 += 1
+            }, onError: { _ in })
+        }, onError: { _ in })
+        networkServiceMock.returnSuccess(with: 10)
+        networkServiceMock.returnSuccess(with: 20)
+        
+        //Then
+        XCTAssertEqual(executionCount1, 1)
+        XCTAssertEqual(executionCount2, 1)
+    }
+    
+    func testReturnSuccessWithSerializedDataForAllRequests() {
+        //Given
+        var executionCount1: Int = 0
+        var executionCount2: Int = 0
+        
+        //When
+        networkServiceMock.request(resource, onCompletion: { _ in
+            executionCount1 += 1
+        }, onError: { _ in })
+        networkServiceMock.request(resource, onCompletion: { _ in
+            executionCount2 += 1
+        }, onError: { _ in })
+        networkServiceMock.returnSuccess(with: 10, count: 2)
+        
+        //Then
+        XCTAssertEqual(executionCount1, 1)
+        XCTAssertEqual(executionCount2, 1)
     }
     
     func testReturnError() {
@@ -98,4 +221,67 @@ class NetworkServiceMockTest: XCTestCase {
         XCTAssertEqual(executionCount, 1)
     }
     
+    func testCorrectOrderOfReturnErrorForMultipleRequests() {
+        //Given
+        var capturedError1: NetworkError?
+        var capturedError2: NetworkError?
+
+        //When
+        networkServiceMock.request(resource, onCompletion: { _ in }, onError: { error in
+            capturedError1 = error
+        })
+        networkServiceMock.request(resource, onCompletion: { _ in }, onError: { error in
+            capturedError2 = error
+        })
+        networkServiceMock.returnError(with: .unknownError)
+        networkServiceMock.returnError(with: .cancelled)
+
+        //Then
+        if case .unknownError? = capturedError1, case .cancelled? = capturedError2 {
+            
+        } else {
+            XCTFail("Wrong order of error responses")
+        }
+    }
+    
+    func testRequestErrorChaining() {
+        //Given
+        var executionCount1: Int = 0
+        var executionCount2: Int = 0
+        
+        //When
+        networkServiceMock.request(resource, onCompletion: { _ in }, onError: { _ in
+            executionCount1 += 1
+            self.networkServiceMock.request(self.resource, onCompletion: { _ in }, onError: { _ in
+                executionCount2 += 1
+            })
+        })
+
+        networkServiceMock.returnError(with: .unknownError)
+        networkServiceMock.returnError(with: .unknownError)
+        
+        //Then
+        XCTAssertEqual(executionCount1, 1)
+        XCTAssertEqual(executionCount2, 1)
+    }
+
+    func testReturnErrorsForAllRequests() {
+        //Given
+        var executionCount1: Int = 0
+        var executionCount2: Int = 0
+
+        //When
+        networkServiceMock.request(resource, onCompletion: { _ in }, onError: { _ in
+            executionCount1 += 1
+        })
+        networkServiceMock.request(resource, onCompletion: { _ in }, onError: { _ in
+            executionCount2 += 1
+        })
+        networkServiceMock.returnError(with: .unknownError, count: 2)
+
+        //Then
+        XCTAssertEqual(executionCount1, 1)
+        XCTAssertEqual(executionCount2, 1)
+    }
+
 }

--- a/Tests/DBNetworkStackTests/RetryNetworkserviceTest.swift
+++ b/Tests/DBNetworkStackTests/RetryNetworkserviceTest.swift
@@ -48,20 +48,24 @@ class RetryNetworkserviceTest: XCTestCase {
         let numberOfRetries = 2
         var executedRetrys = 0
         
+        let retryService = RetryNetworkService(networkService: networkServiceMock, numberOfRetries: numberOfRetries,
+                                               idleTimeInterval: 0, shouldRetry: { _ in return true }, dispatchRetry: { _, block in
+                                                executedRetrys += 1
+                                                block()
+        })
+        
         //When
-        weak var task: NetworkTask?
-        task = RetryNetworkService(networkService: networkServiceMock, numberOfRetries: numberOfRetries,
-                                   idleTimeInterval: 0, shouldRetry: { _ in return true}, dispatchRetry: { _, block in
-            executedRetrys += 1
-            block()
-        }).request(resource, onCompletionWithResponse: { _, _ in
+        weak var task = retryService.request(resource, onCompletion: { _ in
+            XCTAssertEqual(executedRetrys, numberOfRetries)
         }, onError: { _ in
             XCTFail("Expects to not call error block")
         })
-        networkServiceMock.returnError(with: .unknownError, count: errorCount)
+        (0..<errorCount).forEach { _ in
+            networkServiceMock.returnError(with: .unknownError)
+        }
+        networkServiceMock.returnSuccess(with: 1)
         
         //Then
-        XCTAssertEqual(executedRetrys, numberOfRetries)
         XCTAssertNil(task)
     }
     
@@ -72,19 +76,20 @@ class RetryNetworkserviceTest: XCTestCase {
         //When
         weak var task: NetworkTask?
         task = RetryNetworkService(networkService: networkServiceMock, numberOfRetries: 3,
-                                   idleTimeInterval: 0, shouldRetry: { _ in return true},
+                                   idleTimeInterval: 0, shouldRetry: { _ in return true },
                                    dispatchRetry: { _, block in
             executedRetrys += 1
             block()
         }).request(resource, onCompletion: { _ in
              XCTFail("Expects to not call completion block")
         }, onError: { _ in
-            XCTFail("Expects to not call error block")
+            XCTAssertEqual(executedRetrys, 3)
         })
-        networkServiceMock.returnError(with: .unknownError, count: 3)
+        (0..<4).forEach { _ in
+            networkServiceMock.returnError(with: .unknownError)
+        }
         
         //Then
-        XCTAssertEqual(executedRetrys, 3)
         XCTAssertNil(task)
     }
     
@@ -105,7 +110,7 @@ class RetryNetworkserviceTest: XCTestCase {
         }, onError: { error in
            capturedError = error
         })
-        networkServiceMock.returnError(with: .unknownError, count: 3)
+        networkServiceMock.returnError(with: .unknownError)
         
         //Then
         XCTAssertNil(task)

--- a/Tests/DBNetworkStackTests/RetryTaskTest.swift
+++ b/Tests/DBNetworkStackTests/RetryTaskTest.swift
@@ -162,6 +162,30 @@ class RetryTaskTest: XCTestCase {
         XCTAssertNotNil(capturedError)
     }
     
+    func testShouldNotWhenMaximumNumberOfRetrys() {
+        var retryCount = 0
+        let task: RetryNetworkTask<Int> = RetryNetworkTask(maxmimumNumberOfRetries: 3, idleTimeInterval: 0.3,
+                                                            shouldRetry: { _ in return true }, onSuccess: { _, _  in
+                                                                
+        }, onError: { _ in
+            
+        }, retryAction: { _, _ in
+            retryCount += 1
+            return NetworkTaskMock()
+        }, dispatchRetry: { _, block in
+            block()
+        })
+        
+        let onError = task.createOnError()
+        
+        onError(.unknownError)
+        onError(.unknownError)
+        onError(.unknownError)
+        onError(.unknownError)
+        
+        XCTAssertEqual(retryCount, 3)
+    }
+    
     func testResume() {
         //Given
         let taskMock = NetworkTaskMock()


### PR DESCRIPTION
NetworkServiceMock now supports request response chains, where one response leads to an other request.

Fixes issues: 

New feature:

#### Make sure to check all boxes before merging

- [x] Method/Class documentation
- [x] README.md documentation
- [x] Unit tests for new features/regressions
