### PR TITLE
imporves SwiftLint

### DIFF
--- a/DBNetworkStack.xcodeproj/project.pbxproj
+++ b/DBNetworkStack.xcodeproj/project.pbxproj
@@ -392,7 +392,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \\\"${CONFIGURATION}\\\" != \\\"Release\\\" ];\nthen if which swiftlint >/dev/null;\nthen\nswiftlint\nelse\necho \\\"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\\\"\nfi\nfi\n\n";
+			shellScript = "if [ \\\"${CONFIGURATION}\\\" != \\\"Release\\\" ];\nthen if which swiftlint >/dev/null;\nthen\nswiftlint\nelse\necho \\\"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\\\"\nfi\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/DBNetworkStack.xcodeproj/project.pbxproj
+++ b/DBNetworkStack.xcodeproj/project.pbxproj
@@ -392,7 +392,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if [ \\\"${CONFIGURATION}\\\" != \\\"Release\\\" ];\nthen if which swiftlint >/dev/null;\nthen\nswiftlint\nelse\necho \\\"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\\\"\nfi\nfi\n\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Tests/DBNetworkStackTests/URLRequestConvertibleTest.swift
+++ b/Tests/DBNetworkStackTests/URLRequestConvertibleTest.swift
@@ -51,7 +51,12 @@ class URLRequestConvertibleTest: XCTestCase {
         let httpHeaderFields = ["header": "HeaderValue"]
         
         //When
-        let request = URLRequest(path: path, baseURL: .defaultMock, HTTPMethod: .DELETE, parameters: parameters, body: body, allHTTPHeaderFields: httpHeaderFields)
+        let request = URLRequest(path: path,
+                                 baseURL: .defaultMock,
+                                 HTTPMethod: .DELETE,
+                                 parameters: parameters,
+                                 body: body,
+                                 allHTTPHeaderFields: httpHeaderFields)
         
         //Then
         let reuqestURL: URL! = request.url


### PR DESCRIPTION
Fixes issues: 
#90 
When installing DBNetworkStack with Carthage and a new version of SwiftLint, some new created SwiftLint rules can break installation. If you use Carthage with `Debug` option enabled, the issue still exists.

New feature:

Only lint in `DEBUG` mode.

#### Make sure to check all boxes before merging

- [x] Method/Class documentation
- [x] README.md documentation
- [x] Unit tests for new features/regressions