### PR TITLE
makes parameter non-optional

### DIFF
--- a/Source/URLRequestConvertible.swift
+++ b/Source/URLRequestConvertible.swift
@@ -54,14 +54,14 @@ extension URLRequest {
     ///
     /// - Important: path must not start with a `/`
     public init(path: String, baseURL: URL,
-                HTTPMethod: HTTPMethod = .GET, parameters: [String: String] = [:],
+                HTTPMethod: HTTPMethod = .GET, parameters: [String: String]? = nil,
                 body: Data? = nil, allHTTPHeaderFields: Dictionary<String, String>? = nil) {
         guard let url = URL(string: path, relativeTo: baseURL) else {
             fatalError("Error creating absolute URL from path: \(path), with baseURL: \(baseURL)")
         }
         
         let urlWithParameters: URL
-        if !parameters.isEmpty {
+        if let parameters = parameters, !parameters.isEmpty {
             urlWithParameters = url.appending(queryParameters: parameters)
         } else {
             urlWithParameters = url

--- a/Source/URLRequestConvertible.swift
+++ b/Source/URLRequestConvertible.swift
@@ -48,7 +48,7 @@ extension URLRequest {
     ///   - path: path to the resource.
     ///   - baseURL: the base url of the resource.
     ///   - HTTPMethod: the HTTP method for the request. Defaults to `.GET`
-    ///   - parameters: url parameters for the request. Defaults to `nil`
+    ///   - parameters: url parameters for the request. Defaults to empty dictionary
     ///   - body: body data payload. Defaults to `nil`
     ///   - allHTTPHeaderFields: HTTP request header fields. Defaults to `nil`
     ///

--- a/Source/URLRequestConvertible.swift
+++ b/Source/URLRequestConvertible.swift
@@ -54,14 +54,14 @@ extension URLRequest {
     ///
     /// - Important: path must not start with a `/`
     public init(path: String, baseURL: URL,
-                HTTPMethod: HTTPMethod = .GET, parameters: [String: String]? = nil,
+                HTTPMethod: HTTPMethod = .GET, parameters: [String: String] = [:],
                 body: Data? = nil, allHTTPHeaderFields: Dictionary<String, String>? = nil) {
         guard let url = URL(string: path, relativeTo: baseURL) else {
             fatalError("Error creating absolute URL from path: \(path), with baseURL: \(baseURL)")
         }
         
         let urlWithParameters: URL
-        if let parameters = parameters {
+        if !parameters.isEmpty {
             urlWithParameters = url.appending(queryParameters: parameters)
         } else {
             urlWithParameters = url

--- a/Tests/DBNetworkStackTests/URLRequestConvertibleTest.swift
+++ b/Tests/DBNetworkStackTests/URLRequestConvertibleTest.swift
@@ -84,4 +84,19 @@ class URLRequestConvertibleTest: XCTestCase {
         XCTAssert(query?.contains(where: { $0.name == "query" && $0.value == "2" }) ?? false)
     }
 
+    func testNoTrailingQuestionmarkInRequestURL() {
+        //Given
+        let path = "http://bahn.de/train"
+
+        //When
+        let request = URLRequest(path: path, baseURL: .defaultMock, parameters: [:])
+
+        //Then
+        if let contains = request.url?.absoluteString.contains("?") {
+            XCTAssertFalse(contains)
+        } else {
+            XCTFail("request seem to have no url")
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes issues: 

New feature:

-  query parameter in URLRequestConvertible init are not optional anymore 

#### Make sure to check all boxes before merging

- [x] Method/Class documentation
- [x] README.md documentation
- [x] Unit tests for new features/regressions
